### PR TITLE
feat(backend): recurring expenses

### DIFF
--- a/backend/migrations/Version20260208193500.php
+++ b/backend/migrations/Version20260208193500.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260208193500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add recurring expense schedules and link generated expenses to schedule.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE recurring_expense (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, calendar_id INT NOT NULL, category_id INT NOT NULL, amount DOUBLE PRECISION NOT NULL, label VARCHAR(255) NOT NULL, description LONGTEXT DEFAULT NULL, confirmed TINYINT(1) NOT NULL, start_at DATETIME NOT NULL, next_run_at DATETIME NOT NULL, end_at DATETIME DEFAULT NULL, frequency VARCHAR(255) NOT NULL, `interval` INT NOT NULL, active TINYINT(1) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, INDEX IDX_8C88E6BDA76ED395 (user_id), INDEX IDX_8C88E6BD3E3C8C06 (calendar_id), INDEX IDX_8C88E6BD12469DE2 (category_id), INDEX IDX_8C88E6BDFE5B8E3E (next_run_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE recurring_expense ADD CONSTRAINT FK_8C88E6BDA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE recurring_expense ADD CONSTRAINT FK_8C88E6BD3E3C8C06 FOREIGN KEY (calendar_id) REFERENCES calendar (id)');
+        $this->addSql('ALTER TABLE recurring_expense ADD CONSTRAINT FK_8C88E6BD12469DE2 FOREIGN KEY (category_id) REFERENCES category (id)');
+
+        $this->addSql('ALTER TABLE expense ADD recurring_expense_id INT DEFAULT NULL, ADD recurring_occurrence_at DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA9A50F1DC FOREIGN KEY (recurring_expense_id) REFERENCES recurring_expense (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_2D3A8DA9A50F1DC ON expense (recurring_expense_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_EXPENSE_RECURRING_OCCURRENCE ON expense (recurring_expense_id, recurring_occurrence_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense DROP FOREIGN KEY FK_2D3A8DA9A50F1DC');
+        $this->addSql('DROP INDEX UNIQ_EXPENSE_RECURRING_OCCURRENCE ON expense');
+        $this->addSql('DROP INDEX IDX_2D3A8DA9A50F1DC ON expense');
+        $this->addSql('ALTER TABLE expense DROP recurring_expense_id, DROP recurring_occurrence_at');
+
+        $this->addSql('DROP TABLE recurring_expense');
+    }
+}

--- a/backend/src/Command/GenerateRecurringExpensesCommand.php
+++ b/backend/src/Command/GenerateRecurringExpensesCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\RecurringExpense\RecurringExpenseGeneratorService;
+use DateTime;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:recurring-expenses:generate',
+    description: 'Generate due recurring expense occurrences',
+)]
+class GenerateRecurringExpensesCommand extends Command
+{
+    public function __construct(
+        private readonly RecurringExpenseGeneratorService $generator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('now', null, InputOption::VALUE_OPTIONAL, 'Override current time (Y-m-d H:i:s)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $now = $input->getOption('now');
+        $nowDt = $now ? new DateTime((string) $now) : new DateTime();
+
+        $count = $this->generator->generate($nowDt);
+        $output->writeln(sprintf('Generated %d recurring expense(s).', $count));
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Entity/Expense.php
+++ b/backend/src/Entity/Expense.php
@@ -53,6 +53,13 @@ class Expense
     #[Groups(ExpenseContextGroupConst::ALWAYS)]
     private DateTime $createdAt;
 
+    #[ORM\ManyToOne(targetEntity: RecurringExpense::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?RecurringExpense $recurringExpense = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?DateTime $recurringOccurrenceAt = null;
+
     public function __construct()
     {
         $this->createdAt = new DateTime();
@@ -163,6 +170,28 @@ class Expense
     {
         $this->createdAt = $createdAt;
 
+        return $this;
+    }
+
+    public function getRecurringExpense(): ?RecurringExpense
+    {
+        return $this->recurringExpense;
+    }
+
+    public function setRecurringExpense(?RecurringExpense $recurringExpense): self
+    {
+        $this->recurringExpense = $recurringExpense;
+        return $this;
+    }
+
+    public function getRecurringOccurrenceAt(): ?DateTime
+    {
+        return $this->recurringOccurrenceAt;
+    }
+
+    public function setRecurringOccurrenceAt(?DateTime $recurringOccurrenceAt): self
+    {
+        $this->recurringOccurrenceAt = $recurringOccurrenceAt;
         return $this;
     }
 

--- a/backend/src/Entity/RecurringExpense.php
+++ b/backend/src/Entity/RecurringExpense.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Enum\RecurringFrequency;
+use App\Repository\RecurringExpenseRepository;
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Template/schedule for generating recurring expenses.
+ *
+ * @codeCoverageIgnore
+ */
+#[ORM\Entity(repositoryClass: RecurringExpenseRepository::class)]
+#[ORM\Index(fields: ['nextRunAt'])]
+class RecurringExpense
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    private User $user;
+
+    #[ORM\ManyToOne(targetEntity: Calendar::class)]
+    private Calendar $calendar;
+
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    private Category $category;
+
+    #[ORM\Column]
+    private float $amount = 0;
+
+    #[ORM\Column]
+    private string $label;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column]
+    private bool $confirmed = false;
+
+    #[ORM\Column]
+    private DateTime $startAt;
+
+    #[ORM\Column]
+    private DateTime $nextRunAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?DateTime $endAt = null;
+
+    #[ORM\Column(enumType: RecurringFrequency::class)]
+    private RecurringFrequency $frequency;
+
+    #[ORM\Column]
+    private int $interval = 1;
+
+    #[ORM\Column]
+    private bool $active = true;
+
+    #[ORM\Column]
+    private DateTime $createdAt;
+
+    #[ORM\Column]
+    private DateTime $updatedAt;
+
+    public function __construct()
+    {
+        $now = new DateTime();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function touch(): void
+    {
+        $this->updatedAt = new DateTime();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getCalendar(): Calendar
+    {
+        return $this->calendar;
+    }
+
+    public function setCalendar(Calendar $calendar): self
+    {
+        $this->calendar = $calendar;
+        return $this;
+    }
+
+    public function getCategory(): Category
+    {
+        return $this->category;
+    }
+
+    public function setCategory(Category $category): self
+    {
+        $this->category = $category;
+        return $this;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(float $amount): self
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): self
+    {
+        $this->label = $label;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->confirmed;
+    }
+
+    public function setConfirmed(bool $confirmed): self
+    {
+        $this->confirmed = $confirmed;
+        return $this;
+    }
+
+    public function getStartAt(): DateTime
+    {
+        return $this->startAt;
+    }
+
+    public function setStartAt(DateTime $startAt): self
+    {
+        $this->startAt = $startAt;
+        return $this;
+    }
+
+    public function getNextRunAt(): DateTime
+    {
+        return $this->nextRunAt;
+    }
+
+    public function setNextRunAt(DateTime $nextRunAt): self
+    {
+        $this->nextRunAt = $nextRunAt;
+        return $this;
+    }
+
+    public function getEndAt(): ?DateTime
+    {
+        return $this->endAt;
+    }
+
+    public function setEndAt(?DateTime $endAt): self
+    {
+        $this->endAt = $endAt;
+        return $this;
+    }
+
+    public function getFrequency(): RecurringFrequency
+    {
+        return $this->frequency;
+    }
+
+    public function setFrequency(RecurringFrequency $frequency): self
+    {
+        $this->frequency = $frequency;
+        return $this;
+    }
+
+    public function getInterval(): int
+    {
+        return $this->interval;
+    }
+
+    public function setInterval(int $interval): self
+    {
+        $this->interval = $interval;
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
+        return $this;
+    }
+}

--- a/backend/src/Enum/RecurringFrequency.php
+++ b/backend/src/Enum/RecurringFrequency.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * @codeCoverageIgnore
+ */
+enum RecurringFrequency: string
+{
+    case DAILY = 'daily';
+    case WEEKLY = 'weekly';
+    case MONTHLY = 'monthly';
+    case YEARLY = 'yearly';
+}

--- a/backend/src/Repository/RecurringExpenseRepository.php
+++ b/backend/src/Repository/RecurringExpenseRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\RecurringExpense;
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RecurringExpense>
+ */
+class RecurringExpenseRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RecurringExpense::class);
+    }
+
+    public function save(RecurringExpense $entity): void
+    {
+        $entity->touch();
+
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+    }
+
+    public function findDue(DateTime $now): array
+    {
+        return $this->createQueryBuilder('r')
+            ->andWhere('r.active = true')
+            ->andWhere('r.nextRunAt <= :now')
+            ->setParameter('now', $now)
+            ->orderBy('r.nextRunAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/backend/src/Request/Expense/CreateExpenseRequest.php
+++ b/backend/src/Request/Expense/CreateExpenseRequest.php
@@ -12,6 +12,8 @@ use App\Request\AbstractRequest;
 use DateTime;
 use Symfony\Component\Validator\Constraints as Assert;
 
+use App\Request\Expense\RecurringRuleRequest;
+
 class CreateExpenseRequest extends AbstractRequest
 {
     #[Assert\NotBlank]
@@ -34,6 +36,11 @@ class CreateExpenseRequest extends AbstractRequest
 
     #[Assert\NotBlank]
     protected DateTime $createdAt;
+
+    /**
+     * When set, backend will create a recurring schedule and keep generating expenses.
+     */
+    protected ?RecurringRuleRequest $recurringRule = null;
 
     public function getCalendar(): Calendar
     {
@@ -98,6 +105,17 @@ class CreateExpenseRequest extends AbstractRequest
     public function isConfirmed(): bool
     {
         return $this->confirmed;
+    }
+
+    public function getRecurringRule(): ?RecurringRuleRequest
+    {
+        return $this->recurringRule;
+    }
+
+    public function setRecurringRule(?RecurringRuleRequest $recurringRule): self
+    {
+        $this->recurringRule = $recurringRule;
+        return $this;
     }
 
     public function setConfirmed(bool $confirmed): self

--- a/backend/src/Request/Expense/RecurringRuleRequest.php
+++ b/backend/src/Request/Expense/RecurringRuleRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Request\Expense;
+
+use App\Enum\RecurringFrequency;
+use DateTime;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class RecurringRuleRequest
+{
+    #[Assert\NotBlank]
+    public RecurringFrequency $frequency;
+
+    #[Assert\GreaterThanOrEqual(1)]
+    public int $interval = 1;
+
+    #[Assert\NotBlank]
+    public DateTime $startAt;
+
+    public ?DateTime $endAt = null;
+
+    public function getFrequency(): RecurringFrequency
+    {
+        return $this->frequency;
+    }
+
+    public function getInterval(): int
+    {
+        return $this->interval;
+    }
+
+    public function getStartAt(): DateTime
+    {
+        return $this->startAt;
+    }
+
+    public function getEndAt(): ?DateTime
+    {
+        return $this->endAt;
+    }
+}

--- a/backend/src/Service/RecurringExpense/RecurringExpenseCalculator.php
+++ b/backend/src/Service/RecurringExpense/RecurringExpenseCalculator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\RecurringExpense;
+
+use App\Entity\RecurringExpense;
+use App\Enum\RecurringFrequency;
+use DateInterval;
+use DateTime;
+
+class RecurringExpenseCalculator
+{
+    public function calculateNextRunAt(RecurringExpense $recurringExpense, DateTime $from): DateTime
+    {
+        $interval = max(1, $recurringExpense->getInterval());
+
+        $next = clone $from;
+
+        // Keep the time part from $from.
+        // We rely on DateTime's add() semantics for month boundaries.
+        switch ($recurringExpense->getFrequency()) {
+            case RecurringFrequency::DAILY:
+                $next->add(new DateInterval(sprintf('P%dD', $interval)));
+                break;
+            case RecurringFrequency::WEEKLY:
+                $next->add(new DateInterval(sprintf('P%dW', $interval)));
+                break;
+            case RecurringFrequency::MONTHLY:
+                $next->add(new DateInterval(sprintf('P%dM', $interval)));
+                break;
+            case RecurringFrequency::YEARLY:
+                $next->add(new DateInterval(sprintf('P%dY', $interval)));
+                break;
+        }
+
+        return $next;
+    }
+}

--- a/backend/src/Service/RecurringExpense/RecurringExpenseGeneratorService.php
+++ b/backend/src/Service/RecurringExpense/RecurringExpenseGeneratorService.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\RecurringExpense;
+
+use App\Entity\Expense;
+use App\Entity\RecurringExpense;
+use App\Repository\ExpenseRepository;
+use App\Repository\RecurringExpenseRepository;
+use DateTime;
+
+readonly class RecurringExpenseGeneratorService
+{
+    public function __construct(
+        private RecurringExpenseRepository $recurringExpenseRepository,
+        private ExpenseRepository $expenseRepository,
+        private RecurringExpenseCalculator $calculator,
+    ) {
+    }
+
+    /**
+     * Generate due recurring expenses up to $now.
+     *
+     * @return int number of generated Expense rows
+     */
+    public function generate(DateTime $now): int
+    {
+        $generated = 0;
+
+        /** @var RecurringExpense $schedule */
+        foreach ($this->recurringExpenseRepository->findDue($now) as $schedule) {
+            // Skip schedules that ended.
+            if ($schedule->getEndAt() !== null && $schedule->getNextRunAt() > $schedule->getEndAt()) {
+                $schedule->setActive(false);
+                $this->recurringExpenseRepository->save($schedule);
+                continue;
+            }
+
+            // Generate occurrences until we're caught up.
+            while ($schedule->getNextRunAt() <= $now) {
+                $occurrenceAt = clone $schedule->getNextRunAt();
+
+                if ($schedule->getEndAt() !== null && $occurrenceAt > $schedule->getEndAt()) {
+                    $schedule->setActive(false);
+                    break;
+                }
+
+                $expense = (new Expense())
+                    ->setUser($schedule->getUser())
+                    ->setCalendar($schedule->getCalendar())
+                    ->setCategory($schedule->getCategory())
+                    ->setLabel($schedule->getLabel())
+                    ->setDescription($schedule->getDescription())
+                    ->setAmount($schedule->getAmount())
+                    ->setConfirmed($schedule->isConfirmed())
+                    ->setCreatedAt($occurrenceAt)
+                    ->setRecurringExpense($schedule)
+                    ->setRecurringOccurrenceAt($occurrenceAt)
+                ;
+
+                // ExpenseRepository->save() flushes; unique index ensures idempotency.
+                $this->expenseRepository->save($expense);
+                $generated++;
+
+                $schedule->setNextRunAt($this->calculator->calculateNextRunAt($schedule, $occurrenceAt));
+            }
+
+            $this->recurringExpenseRepository->save($schedule);
+        }
+
+        return $generated;
+    }
+}

--- a/backend/tests/Application/Service/RecurringExpense/RecurringExpenseCalculatorTest.php
+++ b/backend/tests/Application/Service/RecurringExpense/RecurringExpenseCalculatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Service\RecurringExpense;
+
+use App\Entity\RecurringExpense;
+use App\Enum\RecurringFrequency;
+use App\Service\RecurringExpense\RecurringExpenseCalculator;
+use App\Tests\ApplicationTestCase;
+use DateTime;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(RecurringExpenseCalculator::class)]
+class RecurringExpenseCalculatorTest extends ApplicationTestCase
+{
+    public function testMonthlyInterval(): void
+    {
+        $schedule = (new RecurringExpense())
+            ->setFrequency(RecurringFrequency::MONTHLY)
+            ->setInterval(1);
+
+        $calc = self::getContainer()->get(RecurringExpenseCalculator::class);
+
+        $from = new DateTime('2026-02-08 10:00:00');
+        $next = $calc->calculateNextRunAt($schedule, $from);
+
+        self::assertSame('2026-03-08 10:00:00', $next->format('Y-m-d H:i:s'));
+    }
+}


### PR DESCRIPTION
Implements recurring payments/transactions in backend.

What’s included:
- New entity: RecurringExpense (schedule/template)
- New enum: RecurringFrequency (daily/weekly/monthly/yearly)
- Expense now optionally links to schedule + occurrence timestamp (idempotency via unique index)
- Generator service + console command: app:recurring-expenses:generate
- Create expense API now accepts optional recurringRule to create schedule on the fly
- Migration included

API shape (create expense):
- POST /api/expense supports optional "recurringRule": { frequency, interval, startAt, endAt }

Notes / follow-ups:
- This PR focuses on backend; UI changes can be added separately.
- Editing/canceling schedules and ‘edit single vs series’ not included yet.
