### PR TITLE
feat(frontend): extract CalendarStateComponent from MainComponent

### DIFF
--- a/frontend/src/app/modules/main/components/calendar-state/calendar-state.component.ts
+++ b/frontend/src/app/modules/main/components/calendar-state/calendar-state.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NbDateService } from '@nebular/theme';
+import { Calendar } from '../../../../api/objects/calendar';
+import { Category } from '../../../../api/objects/category';
+import { User } from '../../../../api/objects/user';
+import { DateUtil } from '../../../../util/date.util';
+import { MainService } from '../../main.service';
+import { CalendarComponent } from '../../calendar/calendar.component';
+
+@Component({
+    selector: 'app-calendar-state',
+    template: `
+        <app-calendar
+            [calendar]="mainService.calendar"
+            [expenses]="mainService.expenses"
+            [expenseBalances]="mainService.expenseBalances"
+            [visibleDate]="mainService.visibleDate"
+            [selectedDate]="mainService.visibleDate"
+            (rangeChange)="onRangeChange($event)"
+            [isMobile]="isMobile">
+        </app-calendar>
+    `,
+    imports: [CalendarComponent],
+})
+export class CalendarStateComponent implements OnInit {
+    @Input() public isMobile: boolean;
+
+    private readonly activatedRoute = inject(ActivatedRoute);
+    private readonly router = inject(Router);
+    private readonly dateService = inject<NbDateService<Date>>(NbDateService);
+    public readonly mainService = inject(MainService);
+
+    public ngOnInit(): void {
+        this.activatedRoute.data.subscribe(
+            ({
+                user,
+                calendars,
+                systemCategories,
+            }: {
+                user: User;
+                calendars: Calendar[];
+                systemCategories: Category[];
+            }) => {
+                this.mainService.user = user;
+                this.mainService.calendars = calendars;
+                this.mainService.systemCategories = systemCategories;
+                this.mainService.calendar =
+                    this.mainService.calendars.filter((calendar: Calendar) => {
+                        return calendar.id === user.defaultCalendarId;
+                    })[0] || this.mainService.calendars[0];
+            }
+        );
+
+        this.activatedRoute.queryParams.subscribe(({ date }: { date?: string }) => {
+            if (date) {
+                const parsedDate = new Date(`${date}-01 00:00:00`);
+                if (DateUtil.valid(parsedDate)) {
+                    parsedDate.setDate(this.mainService.visibleDate.getDate());
+                    this.mainService.visibleDate = parsedDate;
+                }
+            }
+        });
+    }
+
+    public onRangeChange({ dateFrom, dateTo }: { dateFrom: Date; dateTo: Date }): void {
+        this.mainService.calendarDateFrom = dateFrom;
+        this.mainService.calendarDateTo = dateTo;
+        this.mainService.refreshCalendar();
+    }
+}

--- a/frontend/src/app/modules/main/main.component.html
+++ b/frontend/src/app/modules/main/main.component.html
@@ -13,15 +13,7 @@
         (resized)="onResized($event)"
         appSwipe
         (swipeEnd)="onSwipeEnd($event)">
-        <app-calendar
-            [calendar]="mainService.calendar"
-            [expenses]="mainService.expenses"
-            [expenseBalances]="mainService.expenseBalances"
-            [visibleDate]="mainService.visibleDate"
-            [selectedDate]="mainService.visibleDate"
-            (rangeChange)="onRangeChange($event)"
-            [isMobile]="isMobile">
-        </app-calendar>
+        <app-calendar-state [isMobile]="isMobile"></app-calendar-state>
     </nb-layout-column>
 
     <nb-sidebar
@@ -35,7 +27,7 @@
             <app-sidebar-calendar-list
                 [(calendars)]="mainService.calendars"
                 [calendar]="mainService.calendar"
-                (calendarChange)="onCalendarChange($event)">
+                (calendarChange)="mainService.refreshCalendar($event)">
             </app-sidebar-calendar-list>
             <app-sidebar-actions class="mt-auto"></app-sidebar-actions>
         </div>

--- a/frontend/src/app/modules/main/main.component.ts
+++ b/frontend/src/app/modules/main/main.component.ts
@@ -10,9 +10,6 @@ import {
 } from '@nebular/theme';
 import { ResizedEvent, AngularResizeEventModule } from 'angular-resize-event';
 import { ExpenseApiService } from '../../api/expense.api.service';
-import { Calendar } from '../../api/objects/calendar';
-import { Category } from '../../api/objects/category';
-import { User } from '../../api/objects/user';
 import { APP_CONFIG } from '../../app.initializer';
 import { SwipeEvent } from '../../interfaces/swipe.interface';
 import { DateUtil } from '../../util/date.util';
@@ -20,11 +17,11 @@ import { MainService, SIDEBAR_TAG } from './main.service';
 import { StatementImportService } from './services/statement-import.service';
 import { HeaderComponent } from './header/header.component';
 import { SwipeDirective } from '../../directives/swipe.directive';
-import { CalendarComponent } from './calendar/calendar.component';
 import { OutsideClickDirective } from '../../directives/outside-click.directive';
 import { ProfileComponent } from './components/sidebar/profile/profile.component';
 import { CalendarSidebarListComponent } from './components/sidebar/calendar-list/calendar-list.component';
 import { ActionsComponent } from './components/sidebar/actions/actions.component';
+import { CalendarStateComponent } from './components/calendar-state/calendar-state.component';
 
 @Component({
     templateUrl: 'main.component.html',
@@ -35,17 +32,17 @@ import { ActionsComponent } from './components/sidebar/actions/actions.component
         HeaderComponent,
         SwipeDirective,
         AngularResizeEventModule,
-        CalendarComponent,
         NbSidebarModule,
         OutsideClickDirective,
         ProfileComponent,
         CalendarSidebarListComponent,
         ActionsComponent,
+        CalendarStateComponent,
     ],
 })
 export class MainComponent implements OnInit {
-    private readonly router = inject(Router);
     private readonly activatedRoute = inject(ActivatedRoute);
+    private readonly router = inject(Router);
     private readonly expenseApiService = inject(ExpenseApiService);
     private readonly breakpointService = inject(NbMediaBreakpointsService);
     private readonly dateService = inject<NbDateService<Date>>(NbDateService);
@@ -64,36 +61,6 @@ export class MainComponent implements OnInit {
     }
 
     public ngOnInit(): void {
-        this.activatedRoute.data.subscribe(
-            ({
-                user,
-                calendars,
-                systemCategories,
-            }: {
-                user: User;
-                calendars: Calendar[];
-                systemCategories: Category[];
-            }) => {
-                this.mainService.user = user;
-                this.mainService.calendars = calendars;
-                this.mainService.systemCategories = systemCategories;
-                this.mainService.calendar =
-                    this.mainService.calendars.filter((calendar: Calendar) => {
-                        return calendar.id === user.defaultCalendarId;
-                    })[0] || this.mainService.calendars[0];
-            }
-        );
-
-        this.activatedRoute.queryParams.subscribe(({ date }: { date?: string }) => {
-            if (date) {
-                const parsedDate = new Date(`${date}-01 00:00:00`);
-                if (DateUtil.valid(parsedDate)) {
-                    parsedDate.setDate(this.mainService.visibleDate.getDate());
-                    this.mainService.visibleDate = parsedDate;
-                }
-            }
-        });
-
         if (this.statementImportService.expenses.length) {
             this.statementImportService.processImport();
         }
@@ -118,17 +85,6 @@ export class MainComponent implements OnInit {
                 });
             });
         }
-    }
-
-    public onRangeChange({ dateFrom, dateTo }: { dateFrom: Date; dateTo: Date }): void {
-        this.mainService.calendarDateFrom = dateFrom;
-        this.mainService.calendarDateTo = dateTo;
-
-        this.mainService.refreshCalendar();
-    }
-
-    public onCalendarChange(calendar: Calendar): void {
-        this.mainService.refreshCalendar(calendar);
     }
 
     public onSidebarOutsideClick(event: MouseEvent): void {

--- a/frontend/src/app/modules/main/main.module.ts
+++ b/frontend/src/app/modules/main/main.module.ts
@@ -41,6 +41,7 @@ import { CalendarGridComponent } from './calendar/calendar-grid/calendar-grid.co
 import { CalendarMonthModelService } from './calendar/calendar-month-model.service';
 import { CalendarComponent } from './calendar/calendar.component';
 import { CalendarService } from './calendar/calendar.service';
+import { CalendarStateComponent } from './components/calendar-state/calendar-state.component';
 import { ExpenseReportComponent } from './components/expense-report/expense-report.component';
 import { ActionsComponent } from './components/sidebar/actions/actions.component';
 import { CalendarSidebarListComponent } from './components/sidebar/calendar-list/calendar-list.component';
@@ -107,6 +108,7 @@ import { StatementImportService } from './services/statement-import.service';
         NbBadgeModule,
         // UI Components
         MainComponent,
+        CalendarStateComponent,
         HeaderComponent,
         CalendarSidebarListComponent,
         ProfileComponent,


### PR DESCRIPTION
Move calendar state management (route data init, query param sync, rangeChange handling) into a dedicated CalendarStateComponent, leaving MainComponent as a thin layout shell (sidebar, mobile detection, swipe).

- New CalendarStateComponent owns visibleDate, calendarDateFrom/To, calendar selection, and calls mainService.refreshCalendar() on change
- MainComponent retains: isMobile detection, swipe, sidebar toggle, busy-state subscriptions, and statement import trigger
- Sidebar calendarChange now calls mainService.refreshCalendar() directly