### PR TITLE
fix(deps): patch security vulnerabilities via overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -447,71 +447,6 @@
                 }
             }
         },
-        "node_modules/@angular-devkit/build-angular/node_modules/@babel/core": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
-                "@babel/helper-compilation-targets": "^7.29.7",
-                "@babel/helper-module-transforms": "^7.29.7",
-                "@babel/helpers": "^7.29.7",
-                "@babel/parser": "^7.29.7",
-                "@babel/template": "^7.29.7",
-                "@babel/traverse": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/@babel/generator": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@angular-devkit/build-angular/node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@angular-devkit/build-angular/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@angular-devkit/build-webpack": {
             "version": "0.2102.18",
             "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.18.tgz",
@@ -664,6 +599,7 @@
             "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "21.4.0",
                 "eslint-scope": "9.1.2"
@@ -694,6 +630,7 @@
             "integrity": "sha512-zOW8FFa9qfbVkZ5TulxDkl1C3+gEjWfAAD5Z2MycA6pjVJQlLYPiTAGq+flOQ3yZfTT0z6kd5rejQMXWI81Dvg==",
             "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -804,76 +741,12 @@
                 }
             }
         },
-        "node_modules/@angular/build/node_modules/@babel/core": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
-                "@babel/helper-compilation-targets": "^7.29.7",
-                "@babel/helper-module-transforms": "^7.29.7",
-                "@babel/helpers": "^7.29.7",
-                "@babel/parser": "^7.29.7",
-                "@babel/template": "^7.29.7",
-                "@babel/traverse": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@babel/generator": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@angular/build/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@angular/cdk": {
             "version": "21.0.6",
             "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.6.tgz",
             "integrity": "sha512-5Gw8mXtKXvcvDMWEciPLRYB6Ja5vsikLAidZsdCEIF6Bc51GmoqT5Tk/Ke+ciCd5Hq9Aco/IcHxT1RC3470lZg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse5": "^8.0.0",
                 "tslib": "^2.3.0"
@@ -890,6 +763,7 @@
             "integrity": "sha512-WOZF4p0SnrmBpNeiOA2pdp9OBvGnOSLWbGdRLXJykyseIiEn7+N+GZp+ZA1aNZB4SWolpYCZfTYwkpo6Sf/LXg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/architect": "0.2102.18",
                 "@angular-devkit/core": "21.2.18",
@@ -924,6 +798,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.17.tgz",
             "integrity": "sha512-hqAQxRfi5ldFE42suAXRcY+JCANrUh7fuSQ/DtZ7L896id5BT/exuv6dWNBC1PyAfQmRbpD5Pt6/pd+tNLyhDQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -940,6 +815,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.17.tgz",
             "integrity": "sha512-p+NdjYiwAz9Zmu2yul0LlMXaFjMISVVa24+/MVMoKFeQeI82QE8jDywPlnOSHQHvdCcQVpS7saeEriZzX3JuBQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -953,6 +829,7 @@
             "integrity": "sha512-KithZ3b0HBFH0NbUcswBcjpN9y09vLbarMD7qmGWTnGUBk4W8cn4sbT8zJyv9CRKg9ZcuUBeJYKUfUPn/u/5OQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -985,6 +862,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.17.tgz",
             "integrity": "sha512-wYHpwIdnUnjQFOJJNqRcGx7LS3u64jT+R9L0TnMR/ViBM9dQgGYImlSikkftg2yrFCNo5aKRxhG2LLskQurVdg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1010,6 +888,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.17.tgz",
             "integrity": "sha512-WKu8XeRSNZo+a+aDDZ3M5OtReF7KYqR/PmZ2l1lSf6N5EEAmc+Ky4aqbRhTL/mTSfHrO4+TDJ4C5A2tFmuwIeA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "tslib": "^2.3.0"
@@ -1040,6 +919,7 @@
             "integrity": "sha512-CkiSHyag6W1cc2n8Y3sC4eYSqTqRslORU7DJnelEoJvh/2KM6/BmxxfjDlL6JcZURiiTPgxNjRgpb9zREj3elg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.0",
                 "@types/babel__core": "7.20.5",
@@ -1064,6 +944,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.17.tgz",
             "integrity": "sha512-ROdSliejY37g1EphYmweYdm5cHM8HY3X4tbWt4ubxmhTyYgfN3nxrxfGQ/n7Mz5tDY9VXVLIGDgjLOGYOo4uTQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1085,6 +966,7 @@
             "version": "21.2.17",
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.17.tgz",
             "integrity": "sha512-r/BU/T8bOTghP3fIXhzYf5wcMcAmhWnAFv3p4asCCPXomaktoas70wYcMaDH+pK1LAFBxLwzBWHm36MpFlTMFg==",
+            "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1104,6 +986,7 @@
             "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.17.tgz",
             "integrity": "sha512-RSCtK5ppAV6y6wfRLHSK2a9Wc/vm8j0wsC+/j9PH9yQmppWFVXDWsg5E39MKOIpnoYVx2+hI6eak6+wYtZTe1A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1143,21 +1026,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -1171,6 +1055,23 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/generator": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core/node_modules/convert-source-map": {
@@ -2914,7 +2815,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -3809,6 +3709,7 @@
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -4834,9 +4735,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4854,9 +4752,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4874,9 +4769,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4894,9 +4786,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4914,9 +4803,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4934,9 +4820,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4954,9 +4837,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5088,6 +4968,7 @@
             "resolved": "https://registry.npmjs.org/@nebular/theme/-/theme-17.0.0.tgz",
             "integrity": "sha512-176Aryv0eESabYd6p+UWvsrFqVsh3oj7BhSqSXus0p5wiZCa1uh4o2uVtcTDpGWB5al3sxCZ7MBG9Xj5OtobWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -5982,9 +5863,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6002,9 +5880,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6022,9 +5897,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6042,9 +5914,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6221,9 +6090,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6238,9 +6104,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6255,9 +6118,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6272,9 +6132,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6289,9 +6146,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6306,9 +6160,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6323,9 +6174,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6340,9 +6188,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6357,9 +6202,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6374,9 +6216,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6391,9 +6230,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6408,9 +6244,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6425,9 +6258,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6968,6 +6798,7 @@
             "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -7091,6 +6922,7 @@
             "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.62.1",
                 "@typescript-eslint/types": "8.62.1",
@@ -7198,6 +7030,7 @@
             "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -7240,6 +7073,7 @@
             "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/scope-manager": "8.62.1",
@@ -7514,6 +7348,7 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7602,6 +7437,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7736,16 +7572,13 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -7976,9 +7809,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.37",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-            "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+            "version": "2.10.41",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+            "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8116,9 +7949,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8142,9 +7975,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "dev": true,
             "funding": [
                 {
@@ -8161,11 +7994,12 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.38",
+                "caniuse-lite": "^1.0.30001799",
+                "electron-to-chromium": "^1.5.376",
+                "node-releases": "^2.0.48",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -8332,9 +8166,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+            "version": "1.0.30001800",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+            "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
             "dev": true,
             "funding": [
                 {
@@ -8352,10 +8186,23 @@
             ],
             "license": "CC-BY-4.0"
         },
+        "node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/chardet": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+            "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
             "dev": true,
             "license": "MIT"
         },
@@ -8364,6 +8211,7 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -8482,19 +8330,6 @@
             },
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/cliui/node_modules/string-width": {
@@ -9276,9 +9111,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.375",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-            "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+            "version": "1.5.387",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+            "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -9389,9 +9224,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-            "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+            "version": "5.24.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+            "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9497,9 +9332,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9516,9 +9351,9 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.47.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
-            "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+            "version": "1.49.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+            "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
             "license": "MIT",
             "workspaces": [
                 "docs",
@@ -9616,6 +9451,7 @@
             "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -9675,6 +9511,7 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -9886,7 +9723,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/eva-icons/-/eva-icons-1.1.3.tgz",
             "integrity": "sha512-QBSEWNbEx1H0numXP1qgxKVCZHonRaky5ft4pGzQBcO4cy7mEja6TuJ8rc7BqX2pmkvetVQWKDH+DK/8y7GTag==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
@@ -9941,6 +9779,7 @@
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -10034,9 +9873,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
             "dev": true,
             "funding": [
                 {
@@ -10563,11 +10402,12 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.25",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-            "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+            "version": "4.12.27",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+            "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -10753,9 +10593,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-            "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10767,7 +10607,7 @@
                 "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -10795,9 +10635,9 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10862,9 +10702,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-            "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11149,19 +10989,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-plain-object": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -11371,7 +11198,8 @@
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
             "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
@@ -11410,6 +11238,7 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -11438,9 +11267,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {
@@ -11557,6 +11386,7 @@
             "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
                 "body-parser": "^1.19.0",
@@ -11742,6 +11572,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/karma/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/karma/node_modules/balanced-match": {
@@ -12043,9 +11889,9 @@
             }
         },
         "node_modules/karma/node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "version": "16.2.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+            "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12108,6 +11954,7 @@
             "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -12262,19 +12109,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/listr2/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/listr2/node_modules/eventemitter3": {
@@ -12438,19 +12272,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/log-update/node_modules/slice-ansi": {
@@ -13025,9 +12846,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "dev": true,
             "funding": [
                 {
@@ -13203,9 +13024,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+            "version": "2.0.50",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13493,19 +13314,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ora/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
         "node_modules/ordered-binary": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
@@ -13547,9 +13355,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13915,6 +13723,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -14103,6 +13912,7 @@
             "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -14202,12 +14012,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -14217,13 +14028,17 @@
             }
         },
         "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/raw-body": {
@@ -14606,6 +14421,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
             "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -14660,6 +14476,7 @@
             "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -14857,9 +14674,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -15207,19 +15024,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
-        "node_modules/slice-ansi/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/smart-buffer": {
@@ -15673,9 +15477,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -15705,6 +15509,7 @@
             "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -15953,7 +15758,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsyringe": {
             "version": "4.10.0",
@@ -16049,6 +15855,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16283,14 +16090,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {
@@ -16326,6 +16136,7 @@
             "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "fdir": "^6.5.0",
@@ -16443,6 +16254,7 @@
             "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -16764,31 +16576,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
-            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -16915,6 +16702,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/webpack-dev-server/node_modules/raw-body": {
@@ -17222,6 +17019,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/wrap-ansi/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -17440,6 +17253,7 @@
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -17458,7 +17272,8 @@
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
             "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         }
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,5 +74,10 @@
         "ts-node": "~10.9.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.62.1"
+    },
+    "overrides": {
+        "http-proxy-middleware": "^3.0.7",
+        "@babel/core": "^7.29.6",
+        "uuid": "^11.1.1"
     }
 }


### PR DESCRIPTION
## Summary
Resolves all 4 open Dependabot alerts by pinning vulnerable transitive dependencies via npm `overrides`.

## Vulnerabilities fixed
| Package | Severity | Fixed version | Issue |
|---------|----------|---------------|-------|
| `http-proxy-middleware` | 🔴 high | ^3.0.7 | CRLF injection in `fixRequestBody` (GHSA-gcq2-9pq2-cxqm) |
| `http-proxy-middleware` | 🟠 medium | ^3.0.7 | Host-header routing bypass (GHSA-64mm-vxmg-q3vj) |
| `@babel/core` | 🟡 low | ^7.29.6 | Arbitrary file read via sourceMappingURL (GHSA-4x5r-pxfx-6jf8) |
| `uuid` | 🟠 moderate | ^11.1.1 | sockjs dependency chain |

## Approach
Used `overrides` in `package.json` instead of `npm audit fix --force` to avoid breaking-change bumps of `@angular-devkit/build-angular`. All affected packages are **dev-only transitive deps** (build tooling / dev server) — not shipped in the production bundle.

## Verification
- ✅ `npm audit` → **0 vulnerabilities**
- ✅ Clean install (regenerated lockfile) with Node v24.13.0 (per .nvmrc)
- ✅ Production build passes (`npm run build`)