### PR TITLE
chore: remove PostHog and ANONYMOUS_DATA_COLLECTION references

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,6 @@ Contributions from the community are more than welcomed! If you'd like to contri
 
 If you encounter any issues or have any questions about Expensave, feel free to [open an issue](https://github.com/algirdasc/expensave/issues) on GitHub.
 
-## Anonymous Data Collection
-
-This application, by default, uses PostHog to collect anonymized data to help us understand app usage and improve the user experience. 
-This includes tracking pageviews and automatically capturing uncaught exceptions. 
-No personal or personalized data is collected or sent. 
-We do this to identify bugs and enhance the features that are most used.
-
-If you prefer not to share this data, you can easily opt out of tracking by
-setting the `ANONYMOUS_DATA_COLLECTION` environment variable to `no`:
-
-```bash
-export ANONYMOUS_DATA_COLLECTION=no
-```
-
 ## Tech Stack
 
 **Frontend:** Angular, Nebular, Bootstrap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       LOCALE: en
       REGISTRATION_DISABLED: no
       TZ: Europe/Vilnius
-      ANONYMOUS_DATA_COLLECTION_DISABLED: no
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
## Summary
PostHog already removed from source code. This PR cleans up remaining references in docs and config.

## Changes
| File | Change |
|------|--------|
| `README.md` | Removed "Anonymous Data Collection" section |
| `docker-compose.yml` | Removed `ANONYMOUS_DATA_COLLECTION_DISABLED` env var |

## Verification
```
grep -ri "posthog\|ANONYMOUS_DATA_COLLECTION" (excl. node_modules/vendor/var/dist)
→ 0 matches
```