### PR TITLE
docs: overhaul README and add interactive install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,169 @@
 # Expensave
 
-Expensave is an open-source application designed to help you track your personal and family expenses effortlessly, enabling better budgeting and financial management. Highly inspired by [Dollarbird](https://dollarbird.co/), Expensave offers intuitive features to monitor your spending habits and stay on top of your finances.
+**Expensave** is a free, open-source self-hosted expense tracker for personal and family budget management. Track spending, share calendars with family members, import bank statements, and monitor your finances — all on your own server.
 
-## Support
-
-This open-source project is developed in my free time. 
-You can support this project by clicking the "Sponsor" button above.
-Your sponsorship will help me dedicate more time and resources to improve the project, add new features, fix bugs, and stay motivated. It also helps me understand that this project is useful not only for me, but for many users like you.
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![GitHub release](https://img.shields.io/github/v/release/algirdasc/expensave)](https://github.com/algirdasc/expensave/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/algirdasc/expensave)](https://hub.docker.com/r/algirdasc/expensave)
 
 ---
 
-# Screenshots
+## Screenshots
 
-## Desktop version
+### Desktop
 
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-calendar.png">
-    <img alt="Calendar view" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-calendar.png" />
+    <img alt="Expensave desktop calendar view" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-calendar.png" />
 </a>
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-expense-dialog.png">
-    <img alt="Expense dialog" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-expense-dialog.png" style="width: 49%; float: left;" />
+    <img alt="Expensave expense dialog" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-expense-dialog.png" style="width: 49%; float: left;" />
 </a>
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-sidebar.png">
-    <img alt="Calendar list" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-sidebar.png" style="width: 49%; float: right;" />
+    <img alt="Expensave sidebar" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/desktop-sidebar.png" style="width: 49%; float: right;" />
 </a>
 <div style="clear: both;"></div>
 
-## Mobile version
+### Mobile
 
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-calendar.png">
-    <img alt="Mobile version calendar view" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-calendar.png" style="width: 32%; float: left;" />
+    <img alt="Expensave mobile calendar view" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-calendar.png" style="width: 32%; float: left;" />
 </a>
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-expense-dialog.png">
-    <img alt="Mobile version expense dialog" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-expense-dialog.png" style="width: 32%; float: left;" />
+    <img alt="Expensave mobile expense dialog" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-expense-dialog.png" style="width: 32%; float: left;" />
 </a>
 <a href="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-sidebar.png">
-    <img alt="Mobile version calendar list" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-sidebar.png" style="width: 32%; float: left;" />
+    <img alt="Expensave mobile sidebar" src="https://raw.githubusercontent.com/algirdasc/expensave/main/docs/images/screenshots/mobile-sidebar.png" style="width: 32%; float: left;" />
 </a>
 <div style="clear: both;"></div>
+
+---
 
 ## Features
 
-- Multiple user support
-- Shared expense calendars between family members
-- Multiple & unlimited expense calendars- Recurring expenses with daily, weekly, monthly, and yearly schedules
-- Import your balance from financial institutions in various [formats](https://github.com/algirdasc/expensave/wiki/Bank-statement-import#supported-banks) 
-- Reports on your spending and income habits
-- Responsive design
-- Mobile [PWA](https://web.dev/explore/progressive-web-apps) application
+- 👥 Multiple user support
+- 📅 Shared expense calendars between family members
+- ♾️ Multiple & unlimited expense calendars
+- 🔁 Recurring expenses — daily, weekly, monthly, and yearly schedules
+- 🏦 Import bank statements in various [formats](https://github.com/algirdasc/expensave/wiki/Bank-statement-import#supported-banks)
+- 📊 Reports on spending and income habits
+- 📱 Mobile [PWA](https://web.dev/explore/progressive-web-apps) — installable on iOS and Android
+- 🎨 Responsive design — works on desktop, tablet, and mobile
 
-## Installation
+---
 
-### Install on Hostinger VPS seamlessly
+## Quick Start
+
+### Option 1 — Automated installer (recommended)
+
+Requires Docker. Installs and starts Expensave interactively:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/algirdasc/expensave/main/install.sh | sudo bash
+```
+
+The installer will:
+- Verify Docker is installed and running
+- Ask whether to use default or custom settings
+- Configure timezone and locale from your OS automatically
+- Generate a secure database password
+- Pull images and start the application
+- Print the URL and credentials when done
+
+---
+
+### Option 2 — Docker Compose (manual)
+
+**1. Create a directory and download the compose file:**
+
+```bash
+mkdir -p /opt/expensave && cd /opt/expensave
+curl -fsSL https://raw.githubusercontent.com/algirdasc/expensave/main/docker-compose.yml -o docker-compose.yml
+```
+
+**2. Create a `.env` file:**
+
+```bash
+cat > .env <<EOF
+TZ=Europe/Vilnius
+LOCALE=en
+REGISTRATION_DISABLED=no
+DB_PASSWORD=change_me_please
+EOF
+```
+
+**3. Start:**
+
+```bash
+docker compose up -d
+```
+
+App is available at **http://localhost:18000**
+
+**Useful commands:**
+
+```bash
+docker compose logs -f          # view logs
+docker compose pull && docker compose up -d   # update to latest
+docker compose down             # stop
+```
+
+---
+
+### Option 3 — Deploy on Hostinger VPS
+
+One-click deploy on a Hostinger VPS with Docker pre-configured:
 
 [![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=https://raw.githubusercontent.com/algirdasc/expensave/refs/heads/main/docker-compose.yml&REFERRALCODE=1ALGIRDAS48#pricing)
 
-## Install self-hosted instance
+---
 
-See wiki: [Installation](https://github.com/algirdasc/expensave/wiki/Installation).
+## Mobile PWA
 
-### Password Reset Email
-
-Password reset emails are sent through Symfony Mailer. See [Mail sending setup](./docs/MAIL_SENDING.md) for generic SMTP configuration and Gmail mailbox setup.
-
-## Installing Mobile Version
+Expensave works as a Progressive Web App — install it on your phone directly from the browser, no app store required.
 
 See wiki: [Using mobile version](https://github.com/algirdasc/expensave/wiki/Using-mobile-version).
 
+---
+
 ## Bank Statement Import
+
+Import your balance from financial institutions in various formats.
 
 See wiki: [Bank statement import](https://github.com/algirdasc/expensave/wiki/Bank-statement-import).
 
-## Contributing
+---
 
-Contributions from the community are more than welcomed! If you'd like to contribute to Expensave, please fork the repository and submit a pull request with your changes. Before submitting a pull request, make sure to:
+## Community & Discussions
 
-- Follow the [contribution guidelines](./docs/CONTRIBUTING.md).
-- Follow coding standards: [Symfony](https://symfony.com/doc/current/contributing/code/standards.html) and [Angular](https://angular.io/guide/styleguide).
-- Write clear and concise commit messages.
-- Test your changes thoroughly.
+Have a question, idea, or want to share how you use Expensave?
+
+👉 **[Join the discussion on GitHub](https://github.com/algirdasc/expensave/discussions)**
+
+- 💡 **Ideas & feature requests** — suggest what you'd like to see
+- ❓ **Q&A** — ask questions and get help from the community
+- 🗣️ **Show & tell** — share your setup or how you use Expensave
+
+---
 
 ## Support
 
-If you encounter any issues or have any questions about Expensave, feel free to [open an issue](https://github.com/algirdasc/expensave/issues) on GitHub.
+### 💬 Bug reports & questions
 
-## Tech Stack
+Found a bug or need help?
 
-**Frontend:** Angular, Nebular, Bootstrap
+- [Open an issue](https://github.com/algirdasc/expensave/issues) for bug reports
+- [Start a discussion](https://github.com/algirdasc/expensave/discussions) for questions and ideas
 
-**Backend:** PHP 8, Symfony
+### ❤️ Financial support
 
-## Acknowledgements
+Expensave is developed and maintained in my free time. If you find it useful, consider supporting the project:
 
-Expensave was highly inspired by [Dollarbird](https://dollarbird.co/).
+- Click the **Sponsor** button at the top of this page
+- Your support helps me dedicate more time to new features, bug fixes, and keeping the project alive
+- It also lets me know that Expensave is useful to others — which means a lot
+
+---
+
+## License
+
+Expensave is open-source software licensed under the [GNU General Public License v3.0](./LICENSE).

--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,7 @@ collect_config() {
         TZ=$(detect_timezone)
         LOCALE=$(detect_locale)
         REGISTRATION_DISABLED="no"
+        ADMIN_NAME=""
         ADMIN_EMAIL=""
         ADMIN_PASSWORD=""
         USE_DEFAULTS=true
@@ -158,11 +159,13 @@ collect_config() {
         if confirm "Disable user registration? (single-user / private instance)" "n"; then
             REGISTRATION_DISABLED="yes"
             printf "\n"
-            info "Registration disabled — an admin account will be created."
-            ask ADMIN_EMAIL "Admin email" "admin@example.com"
+            info "Registration disabled — your account will be created."
+            ask ADMIN_NAME "Your name" ""
+            ask ADMIN_EMAIL "Your email" ""
             ADMIN_PASSWORD=$(gen_password)
         else
             REGISTRATION_DISABLED="no"
+            ADMIN_NAME=""
             ADMIN_EMAIL=""
             ADMIN_PASSWORD=""
         fi
@@ -240,6 +243,7 @@ EOF
         info "Creating admin user: ${ADMIN_EMAIL}"
         docker compose exec -T application php bin/console app:user:create \
             --email="$ADMIN_EMAIL" \
+            --name="$ADMIN_NAME" \
             --password="$ADMIN_PASSWORD" \
             --admin 2>/dev/null || \
         warn "Could not create admin user automatically. Create it manually after startup."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─────────────────────────────────────────────
+#  Expensave Installer
+#  https://github.com/algirdasc/expensave
+# ─────────────────────────────────────────────
+
+REPO="algirdasc/expensave"
+COMPOSE_URL="https://raw.githubusercontent.com/${REPO}/main/docker-compose.yml"
+DEFAULT_INSTALL_DIR="/opt/expensave"
+
+# ── Colors ────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# ── Helpers ───────────────────────────────────
+info()    { printf "  ${BLUE}→${NC} %s\n" "$1"; }
+success() { printf "  ${GREEN}✓${NC} %s\n" "$1"; }
+warn()    { printf "  ${YELLOW}!${NC} %s\n" "$1"; }
+error()   { printf "  ${RED}✗${NC} %s\n" "$1"; }
+header()  { printf "\n${BOLD}%s${NC}\n" "$1"; }
+divider() { printf "${DIM}────────────────────────────────────────${NC}\n"; }
+
+ask() {
+    # ask <var_name> <prompt> <default>
+    local var="$1" prompt="$2" default="$3"
+    printf "  ${BOLD}%s${NC} ${DIM}[%s]${NC}: " "$prompt" "$default"
+    read -r input
+    eval "$var=\"${input:-$default}\""
+}
+
+ask_secret() {
+    # ask_secret <var_name> <prompt>
+    local var="$1" prompt="$2"
+    printf "  ${BOLD}%s${NC}: " "$prompt"
+    read -rs input
+    printf "\n"
+    eval "$var=\"$input\""
+}
+
+confirm() {
+    # confirm <prompt> <default y|n> → returns 0=yes 1=no
+    local prompt="$1" default="${2:-y}"
+    local hint
+    [ "$default" = "y" ] && hint="Y/n" || hint="y/N"
+    printf "  ${BOLD}%s${NC} ${DIM}[%s]${NC}: " "$prompt" "$hint"
+    read -r answer
+    answer="${answer:-$default}"
+    [[ "$answer" =~ ^[Yy] ]]
+}
+
+gen_password() {
+    # 20 char alphanumeric
+    tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20
+}
+
+detect_timezone() {
+    local tz=""
+    if [ -f /etc/timezone ]; then
+        tz=$(cat /etc/timezone)
+    elif [ -L /etc/localtime ]; then
+        tz=$(readlink /etc/localtime | sed 's|.*/zoneinfo/||')
+    elif command -v timedatectl &>/dev/null; then
+        tz=$(timedatectl show --property=Timezone --value 2>/dev/null || true)
+    fi
+    echo "${tz:-UTC}"
+}
+
+detect_locale() {
+    local locale=""
+    if [ -n "${LANG:-}" ]; then
+        locale=$(echo "$LANG" | cut -d_ -f1)
+    elif [ -n "${LC_ALL:-}" ]; then
+        locale=$(echo "$LC_ALL" | cut -d_ -f1)
+    fi
+    echo "${locale:-en}"
+}
+
+# ── Checks ────────────────────────────────────
+check_root() {
+    if [ "$EUID" -ne 0 ]; then
+        error "This script must be run as root (or with sudo)."
+        printf "\n  Try: ${BOLD}sudo bash install.sh${NC}\n\n"
+        exit 1
+    fi
+}
+
+check_docker() {
+    header "Checking requirements"
+    divider
+
+    if ! command -v docker &>/dev/null; then
+        error "Docker is not installed."
+        printf "\n  Docker is required to run Expensave.\n"
+        printf "  Install it from: ${BOLD}https://docs.docker.com/engine/install/${NC}\n\n"
+        printf "  Quick install (Linux):\n"
+        printf "    ${DIM}curl -fsSL https://get.docker.com | bash${NC}\n\n"
+        exit 1
+    fi
+    success "Docker $(docker --version | awk '{print $3}' | tr -d ',')"
+
+    if ! docker compose version &>/dev/null 2>&1; then
+        error "Docker Compose plugin is not installed."
+        printf "\n  Install it from: ${BOLD}https://docs.docker.com/compose/install/${NC}\n\n"
+        exit 1
+    fi
+    success "Docker Compose $(docker compose version --short 2>/dev/null || echo '')"
+
+    if ! docker info &>/dev/null 2>&1; then
+        error "Docker daemon is not running."
+        printf "\n  Start it with: ${BOLD}sudo systemctl start docker${NC}\n\n"
+        exit 1
+    fi
+    success "Docker daemon running"
+}
+
+# ── Configuration ─────────────────────────────
+collect_config() {
+    header "Installation mode"
+    divider
+
+    if confirm "Use default settings?" "y"; then
+        INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+        TZ=$(detect_timezone)
+        LOCALE=$(detect_locale)
+        REGISTRATION_DISABLED="no"
+        ADMIN_EMAIL=""
+        ADMIN_PASSWORD=""
+        USE_DEFAULTS=true
+        printf "\n"
+        info "Install dir : ${INSTALL_DIR}"
+        info "Timezone    : ${TZ}"
+        info "Locale      : ${LOCALE}"
+        info "Registration: enabled"
+    else
+        USE_DEFAULTS=false
+        printf "\n"
+        header "Custom configuration"
+        divider
+
+        ask INSTALL_DIR "Install directory" "$DEFAULT_INSTALL_DIR"
+
+        local detected_tz
+        detected_tz=$(detect_timezone)
+        ask TZ "Timezone" "$detected_tz"
+
+        local detected_locale
+        detected_locale=$(detect_locale)
+        ask LOCALE "Locale" "$detected_locale"
+
+        printf "\n"
+        if confirm "Disable user registration? (single-user / private instance)" "n"; then
+            REGISTRATION_DISABLED="yes"
+            printf "\n"
+            info "Registration disabled — an admin account will be created."
+            ask ADMIN_EMAIL "Admin email" "admin@example.com"
+            ADMIN_PASSWORD=$(gen_password)
+        else
+            REGISTRATION_DISABLED="no"
+            ADMIN_EMAIL=""
+            ADMIN_PASSWORD=""
+        fi
+    fi
+}
+
+# ── Install ───────────────────────────────────
+do_install() {
+    header "Installing Expensave"
+    divider
+
+    # Create install dir
+    info "Creating directory: ${INSTALL_DIR}"
+    mkdir -p "$INSTALL_DIR"
+    cd "$INSTALL_DIR"
+
+    # Generate secrets
+    local db_password
+    db_password=$(gen_password)
+
+    # Download docker-compose.yml
+    info "Downloading docker-compose.yml"
+    curl -fsSL "$COMPOSE_URL" -o docker-compose.yml
+    success "docker-compose.yml downloaded"
+
+    # Write .env
+    info "Writing .env"
+    cat > .env <<EOF
+# Expensave configuration
+# Generated by install.sh on $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+TZ=${TZ}
+LOCALE=${LOCALE}
+REGISTRATION_DISABLED=${REGISTRATION_DISABLED}
+
+# Database (auto-generated — do not share)
+DB_PASSWORD=${db_password}
+EOF
+    success ".env written"
+
+    # Patch docker-compose.yml with env vars
+    info "Configuring docker-compose.yml"
+    # Replace hardcoded env values with references to .env
+    sed -i.bak \
+        -e "s|TZ: Europe/Vilnius|TZ: \${TZ}|g" \
+        -e "s|LOCALE: en|LOCALE: \${LOCALE}|g" \
+        -e "s|REGISTRATION_DISABLED: no|REGISTRATION_DISABLED: \${REGISTRATION_DISABLED}|g" \
+        -e "s|MARIADB_PASSWORD: expensave|MARIADB_PASSWORD: \${DB_PASSWORD}|g" \
+        docker-compose.yml
+    rm -f docker-compose.yml.bak
+    success "docker-compose.yml configured"
+
+    # Pull images
+    info "Pulling Docker images (this may take a few minutes)..."
+    docker compose pull
+    success "Images pulled"
+
+    # Start services
+    info "Starting services..."
+    docker compose up -d
+    success "Services started"
+
+    # Wait for app to be healthy
+    info "Waiting for application to be ready..."
+    local attempts=0
+    until curl -sf "http://localhost:18000/api/ping" &>/dev/null || [ $attempts -ge 30 ]; do
+        sleep 2
+        attempts=$((attempts + 1))
+        printf "."
+    done
+    printf "\n"
+
+    # Create admin user if registration disabled
+    if [ "$REGISTRATION_DISABLED" = "yes" ] && [ -n "$ADMIN_EMAIL" ]; then
+        info "Creating admin user: ${ADMIN_EMAIL}"
+        docker compose exec -T application php bin/console app:user:create \
+            --email="$ADMIN_EMAIL" \
+            --password="$ADMIN_PASSWORD" \
+            --admin 2>/dev/null || \
+        warn "Could not create admin user automatically. Create it manually after startup."
+    fi
+}
+
+# ── Summary ───────────────────────────────────
+print_summary() {
+    local ip
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "localhost")
+
+    printf "\n"
+    divider
+    printf "${GREEN}${BOLD}  Expensave installed successfully!${NC}\n"
+    divider
+    printf "\n"
+    printf "  ${BOLD}App URL:${NC}       http://${ip}:18000\n"
+    printf "  ${BOLD}Install dir:${NC}   ${INSTALL_DIR}\n"
+    printf "\n"
+
+    if [ "$REGISTRATION_DISABLED" = "yes" ] && [ -n "$ADMIN_EMAIL" ]; then
+        printf "  ${BOLD}Admin email:${NC}   ${ADMIN_EMAIL}\n"
+        printf "  ${BOLD}Admin password:${NC} ${YELLOW}${ADMIN_PASSWORD}${NC}\n"
+        printf "\n"
+        warn "Save your password — it will not be shown again!"
+        printf "\n"
+    fi
+
+    printf "  ${BOLD}Manage:${NC}\n"
+    printf "    Start:   ${DIM}cd ${INSTALL_DIR} && docker compose up -d${NC}\n"
+    printf "    Stop:    ${DIM}cd ${INSTALL_DIR} && docker compose down${NC}\n"
+    printf "    Logs:    ${DIM}cd ${INSTALL_DIR} && docker compose logs -f${NC}\n"
+    printf "    Update:  ${DIM}cd ${INSTALL_DIR} && docker compose pull && docker compose up -d${NC}\n"
+    printf "\n"
+    printf "  ${BOLD}Docs:${NC}          https://github.com/${REPO}/wiki\n"
+    printf "\n"
+    divider
+    printf "\n"
+}
+
+# ── Main ──────────────────────────────────────
+main() {
+    clear
+    printf "\n"
+    printf "${BOLD}  ╔═══════════════════════════════════╗${NC}\n"
+    printf "${BOLD}  ║        Expensave Installer        ║${NC}\n"
+    printf "${BOLD}  ║   Self-hosted expense tracking    ║${NC}\n"
+    printf "${BOLD}  ╚═══════════════════════════════════╝${NC}\n"
+    printf "\n"
+
+    check_root
+    check_docker
+    collect_config
+    do_install
+    print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Complete README rewrite + new interactive `install.sh` bash script.

## README changes
- Added badges: GPL-3, release version, Docker pulls
- Reordered sections: title → description → screenshots → features → quick start
- **3 install options**: automated script, manual docker compose, Hostinger one-click
- Added **Community & Discussions** section (GitHub Discussions)
- Consolidated **Support** section (financial support + bug reports/Q&A)
- Removed Contributing and Tech Stack sections
- Fixed features list formatting bug (`calendars- Recurring`)
- Improved `alt` text on all screenshots for SEO

## install.sh
Interactive pure bash installer (zero dependencies):
- Checks Docker + Docker Compose — exits with install instructions if missing
- **Default mode**: auto-detects timezone and locale from OS, uses sane defaults
- **Custom mode**: prompts for install dir, TZ, locale, registration toggle
- Generates secure random DB password
- Downloads `docker-compose.yml`, writes `.env`, pulls images, starts services
- When registration disabled: asks for admin email, generates random password
- Prints app URL + credentials on completion

## Usage
```bash
curl -fsSL https://raw.githubusercontent.com/algirdasc/expensave/main/install.sh | sudo bash
```