### PR TITLE
feat: add app:user:create console command

### DIFF
--- a/backend/src/Command/CreateUserCommand.php
+++ b/backend/src/Command/CreateUserCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Enum\UserRole;
+use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsCommand(
+    name: 'app:user:create',
+    description: 'Create a new user',
+)]
+class CreateUserCommand extends Command
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly ValidatorInterface $validator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('email', null, InputOption::VALUE_REQUIRED, 'User email address')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'User display name')
+            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'User password')
+            ->addOption('admin', null, InputOption::VALUE_NONE, 'Grant admin role')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $email = $input->getOption('email');
+        $name = $input->getOption('name');
+        $password = $input->getOption('password');
+        $isAdmin = (bool) $input->getOption('admin');
+
+        // Interactive prompts for missing options
+        if (!$email) {
+            $email = $io->ask('Email address');
+        }
+
+        if (!$name) {
+            $name = $io->ask('Display name', $email);
+        }
+
+        if (!$password) {
+            $password = $io->askHidden('Password');
+        }
+
+        if (!$email || !$password) {
+            $io->error('Email and password are required.');
+
+            return Command::FAILURE;
+        }
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setName($name ?? $email);
+        $user->setPlainPassword($password);
+        $user->setActive(true);
+        $user->setRole($isAdmin ? UserRole::ADMIN : UserRole::USER);
+
+        $errors = $this->validator->validate($user);
+        if (count($errors) > 0) {
+            foreach ($errors as $error) {
+                $io->error($error->getMessage());
+            }
+
+            return Command::FAILURE;
+        }
+
+        $this->userRepository->save($user);
+
+        $io->success(sprintf(
+            'User "%s" created successfully%s.',
+            $email,
+            $isAdmin ? ' with admin role' : '',
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Command/CreateUserCommand.php
+++ b/backend/src/Command/CreateUserCommand.php
@@ -76,7 +76,7 @@ class CreateUserCommand extends Command
         $errors = $this->validator->validate($user);
         if (count($errors) > 0) {
             foreach ($errors as $error) {
-                $io->error($error->getMessage());
+                $io->error((string) $error->getMessage());
             }
 
             return Command::FAILURE;


### PR DESCRIPTION
## Summary
New Symfony console command to create users from CLI. Required by `install.sh` to create admin user when registration is disabled.

## Usage
```bash
# Interactive
php bin/console app:user:create

# Non-interactive (used by install.sh)
php bin/console app:user:create --email=admin@example.com --name=Admin --password=secret --admin
```

## Options
| Option | Required | Description |
|--------|----------|-------------|
| `--email` | yes | User email address |
| `--name` | no | Display name (defaults to email) |
| `--password` | yes | User password |
| `--admin` | no | Grant admin role |

## Notes
- Falls back to interactive prompts when options are omitted
- Validates via Symfony Validator before persisting
- Password hashed via existing `UserRepository::save()` flow
- Related: PR #522 (`install.sh`)