### PR TITLE
chore: expand .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,36 @@
-# Backend
-/backend/public/bundles
-/backend/var
-/backend/vendor
-/backend/config/secrets
-/backend/config/jwt/*.pem
-/backend/.env.local
-/backend/.env.local.php
-/backend/.env.*.local
-/backend/*.cache
-/backend/*.phar
-/backend/phpunit.xml
+# ─── Root ─────────────────────────────────────────────────────────────────────
+.git
+.github
+.gitignore
+.dockerignore
 
-# Frontend
-/frontend/.angular
-/frontend/dist
+README.md
+LICENSE
+AGENTS.md
+install.sh
+
+docker-compose.yml
+docker-compose.development.yml
+
+docs/
+ai/
+
+# ─── Backend ──────────────────────────────────────────────────────────────────
+backend/var
+backend/vendor
+backend/config/secrets
+backend/config/jwt/*.pem
+backend/.env.local
+backend/.env.local.php
+backend/.env.*.local
+backend/*.cache
+backend/*.phar
+backend/phpunit.xml
+backend/phpstan.neon
+backend/tests/
+backend/public/bundles
+
+# ─── Frontend ─────────────────────────────────────────────────────────────────
+frontend/.angular
+frontend/dist
+frontend/node_modules


### PR DESCRIPTION
## Summary
Expanded `.dockerignore` to exclude everything not needed in the Docker image.

Dockerfile only copies `backend/`, `frontend/`, and `docker/` — everything else was unnecessary build context.

## Excluded
| Category | Files |
|----------|-------|
| Root | `.git`, `.github`, `README.md`, `LICENSE`, `AGENTS.md`, `install.sh`, `docker-compose*.yml`, `docs/`, `ai/` |
| Backend | `tests/`, `phpstan.neon`, `var/`, `vendor/`, `config/secrets`, JWT keys, local env files, cache/phar artifacts, `phpunit.xml` |
| Frontend | `node_modules/`, `dist/`, `.angular/` |

## Benefits
- Smaller build context → faster `docker build`
- No dev/test artifacts leak into image
- No sensitive files (JWT keys, local env) accidentally included