### PR TITLE
chore: sync install.sh to gh-pages, update install URL

### DIFF
--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -1,0 +1,36 @@
+name: Sync install.sh to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - install.sh
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Copy install.sh from main
+        run: git show origin/main:install.sh > install.sh
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add install.sh
+          if git diff --cached --quiet; then
+            echo "No changes."
+          else
+            git commit -m "chore: sync install.sh from main [skip ci]"
+            git push origin gh-pages
+          fi

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 Requires Docker. Installs and starts Expensave interactively:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/algirdasc/expensave/main/install.sh | sudo bash
+curl -fsSL https://expensave.app/install.sh | sudo bash
 ```
 
 The installer will:


### PR DESCRIPTION
## Changes

### GitHub Actions workflow
`.github/workflows/sync-gh-pages.yml` — triggers on `push` to `main` when `install.sh` changes (also `workflow_dispatch` for manual runs):
1. Checkout `gh-pages`
2. Copy `install.sh` from `origin/main`
3. Commit + push if changed (`[skip ci]` to avoid loop)

### URL update
`README.md` install command updated:
```bash
# Before
curl -fsSL https://raw.githubusercontent.com/algirdasc/expensave/main/install.sh | sudo bash

# After
curl -fsSL https://expensave.app/install.sh | sudo bash
```

> Landing page URL will be updated separately in `gh-pages` branch.