### PR TITLE
fix(frontend): clear import state after save and close

### DIFF
--- a/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.ts
+++ b/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.ts
@@ -74,12 +74,19 @@ export class StatementReviewDialogComponent implements OnInit {
         });
 
         expenseDialog.onClose.subscribe((savedExpense: Expense) => {
-            if (!savedExpense) {
+            if (!(savedExpense instanceof Expense)) {
                 return;
             }
 
             this.removeExpenseFromList(expense);
             this.calendarRefreshNeeded = true;
+
+            if (!this.expenses.length) {
+                this.dialogRef.close({
+                    action: DIALOG_ACTION_CLOSE,
+                    calendarRefreshNeeded: this.calendarRefreshNeeded,
+                });
+            }
         });
     }
 

--- a/frontend/src/app/modules/main/services/statement-import.service.ts
+++ b/frontend/src/app/modules/main/services/statement-import.service.ts
@@ -8,6 +8,7 @@ import { ExpenseQueries } from '../../../queries/expense.queries';
 import { StatementImportQueries } from '../../../queries/statement-import.queries';
 import {
     DIALOG_ACTION_CANCEL,
+    DIALOG_ACTION_CLOSE,
     DIALOG_ACTION_IMPORT,
     StatementReviewDialogComponent,
 } from '../dialogs/statement-review-dialog/statement-review-dialog.component';
@@ -140,6 +141,13 @@ export class StatementImportService {
                         break;
                     case DIALOG_ACTION_CANCEL:
                         this.clearImportStorage();
+                        break;
+                    case DIALOG_ACTION_CLOSE:
+                        if (!this.expenses.length) {
+                            this.clearImportStorage();
+                        } else {
+                            this.reloadImportStorage();
+                        }
                         break;
                 }
             });


### PR DESCRIPTION
## Problem

Two related bugs in bank statement import flow:

1. **Transaction stays in list after save** — `expenseDialog.onClose` used truthy check (`!savedExpense`) which could pass for non-Expense values. Changed to `instanceof Expense` for reliable detection.

2. **Pending import shown after all saved individually** — when last expense was saved one-by-one, dialog closed with `DIALOG_ACTION_CLOSE` but `processImport()` had no handler for that action, so localStorage was never cleared.

## Fix

- `statement-review-dialog`: use `instanceof Expense` check; auto-close dialog when last expense is saved
- `statement-import.service`: import `DIALOG_ACTION_CLOSE` constant and handle it — clear storage if empty, reload if not