### PR TITLE
fix(backend): round Revolut import amount to 2 decimals

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -18,7 +18,7 @@
 APP_ENV=prod
 APP_SECRET={REGENERATE_SECRET}
 APP_HASH={REGENERATE_SECRET}
-APP_VERSION=1.0.3
+APP_VERSION=1.0.4
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###

--- a/backend/src/DTO/Statement/Import/Revolut/RevolutStatementRow.php
+++ b/backend/src/DTO/Statement/Import/Revolut/RevolutStatementRow.php
@@ -150,7 +150,7 @@ class RevolutStatementRow implements StatementImportRowInterface
 
     public function getAmount(): float
     {
-        return $this->amount - $this->getFee();
+        return round($this->amount - $this->getFee(), 2);
     }
 
     public function getCreatedAt(): DateTime

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "expensave-frontend",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "expensave-frontend",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "dependencies": {
                 "@angular/animations": "^21.2.16",
                 "@angular/cdk": "~21.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expensave-frontend",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "scripts": {
         "dev": "ng serve --host 0.0.0.0 --port 18002 --disable-host-check",
         "analyze": "eslint src/",


### PR DESCRIPTION
## Problem\nRevolut import uses floating-point subtraction () which can produce precision artifacts like .\n\n## Fix\nRound computed import amount to 2 decimals in .\n\n## Example\n- amount: \n- fee: \n- result now:  (instead of )