### PR TITLE
fix(frontend): update import review on save and delete

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -18,7 +18,7 @@
 APP_ENV=prod
 APP_SECRET={REGENERATE_SECRET}
 APP_HASH={REGENERATE_SECRET}
-APP_VERSION=1.0.3
+APP_VERSION=1.0.4
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "expensave-frontend",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "expensave-frontend",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "dependencies": {
                 "@angular/animations": "^21.2.16",
                 "@angular/cdk": "~21.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expensave-frontend",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "scripts": {
         "dev": "ng serve --host 0.0.0.0 --port 18002 --disable-host-check",
         "analyze": "eslint src/",

--- a/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.html
+++ b/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.html
@@ -17,7 +17,7 @@
         <span>{{ totalExpensesAmount | shortNumber }}</span>
     </nb-card-header>
     <nb-card-body class="p-0">
-        @for (date of groupedDates; track $index) {
+        @for (date of groupedDates; track date) {
             <nb-list>
                 <nb-list-item [@slideAnimation] class="with-background text-hint">
                     <div class="d-flex w-100"><nb-icon icon="calendar-outline" class="me-1" /> {{ date }}</div>
@@ -26,7 +26,7 @@
                     </div>
                 </nb-list-item>
 
-                @for (expense of groupedByDates[date]; track $index) {
+                @for (expense of groupedByDates[date]; track expense.label + '|' + expense.createdAt + '|' + expense.amount) {
                     <nb-list-item
                         [@slideAnimation]
                         (click)="!expense.id ? openExpense(expense) : null"

--- a/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.html
+++ b/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.html
@@ -26,7 +26,10 @@
                     </div>
                 </nb-list-item>
 
-                @for (expense of groupedByDates[date]; track expense.label + '|' + expense.createdAt + '|' + expense.amount) {
+                @for (
+                    expense of groupedByDates[date];
+                    track expense.label + '|' + expense.createdAt + '|' + expense.amount
+                ) {
                     <nb-list-item
                         [@slideAnimation]
                         (click)="!expense.id ? openExpense(expense) : null"

--- a/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.ts
+++ b/frontend/src/app/modules/main/dialogs/statement-review-dialog/statement-review-dialog.component.ts
@@ -57,24 +57,11 @@ export class StatementReviewDialogComponent implements OnInit {
                 showTransferTab: false,
                 showBalanceTab: false,
                 deletable: true,
-                onExpenseDelete: () => {
-                    this.removeExpenseFromList(expense);
-
-                    expenseDialog.close();
-
-                    // Close review if no expenses to import is left
-                    if (!this.expenses.length) {
-                        this.dialogRef.close({
-                            action: DIALOG_ACTION_CLOSE,
-                            calendarRefreshNeeded: this.calendarRefreshNeeded,
-                        });
-                    }
-                },
             },
         });
 
-        expenseDialog.onClose.subscribe((savedExpense: Expense) => {
-            if (!(savedExpense instanceof Expense)) {
+        expenseDialog.onClose.subscribe((result: Expense | boolean | undefined) => {
+            if (!result) {
                 return;
             }
 
@@ -125,15 +112,14 @@ export class StatementReviewDialogComponent implements OnInit {
     }
 
     public removeExpenseFromList(expense: Expense): void {
-        const index = this.expenses.indexOf(expense);
-        if (index === -1) {
+        if (this.expenses.indexOf(expense) === -1) {
             return;
         }
 
-        this.expenses.splice(index, 1);
+        this.expenses = this.expenses.filter(item => item !== expense);
 
         this.reloadGroupedExpenses();
-        this.onImportChange(this.expenses);
+        this.onImportChange([...this.expenses]);
     }
 
     private reloadGroupedExpenses(): void {


### PR DESCRIPTION
Statement review dialog did not refresh when an expense was saved or deleted individually. Now any truthy dialogRef result triggers immutable removal, and @for track keys are stable to keep DOM in sync.