### PR TITLE
fix(frontend): restore RouterLink in sidebar actions so Reports opens

### DIFF
--- a/frontend/src/app/modules/main/components/sidebar/actions/actions.component.ts
+++ b/frontend/src/app/modules/main/components/sidebar/actions/actions.component.ts
@@ -6,13 +6,13 @@ import { CategoriesDialogComponent } from '../../../dialogs/categories-dialog/ca
 import { AdminUsersDialogComponent } from '../../../dialogs/admin-users-dialog/admin-users-dialog.component';
 import { ProfileDialogComponent } from '../../../dialogs/profile-dialog/profile-dialog.component';
 import { StatementImportService } from '../../../services/statement-import.service';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ConfirmDialogComponent } from '../../../dialogs/confirm-dialog/confirm-dialog.component';
 
 @Component({
     selector: 'app-sidebar-actions',
     templateUrl: 'actions.component.html',
-    imports: [NbActionsModule, NbTooltipModule, NbButtonModule, NbIconModule],
+    imports: [NbActionsModule, RouterLink, NbTooltipModule, NbButtonModule, NbIconModule],
 })
 export class ActionsComponent {
     @Input()


### PR DESCRIPTION
## Problem
Clicking the Reports icon in the sidebar did nothing.

## Root cause
Commit 937c479 ("styling fixes #541") accidentally removed `RouterLink` from `ActionsComponent` imports. The `routerLink="/reports"` attribute on the `nb-action` element became a plain no-op attribute, so clicks stopped navigating.

## Fix
Re-add `RouterLink` to the standalone component's imports in `frontend/src/app/modules/main/components/sidebar/actions/actions.component.ts`.

## Verification
- `ng build` passes.
- Clicking the Reports icon navigates to `/reports` again.