### PR TITLE
fix(frontend): surface search matches hidden behind calendar day overflow

### DIFF
--- a/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.html
+++ b/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.html
@@ -31,7 +31,13 @@
         }
 
         @if (!!invisibleExpensesCount) {
-            <a href="#" (click)="$event.preventDefault(); openInvisibleExpenses()" class="other-label px-1">
+            <a
+                href="#"
+                (click)="$event.preventDefault(); openInvisibleExpenses()"
+                class="other-label px-1"
+                [class.expense-dimmed]="hasSearchQuery && !invisibleSearchMatchesCount"
+                [class.has-search-matches]="!!invisibleSearchMatchesCount"
+                [attr.title]="invisibleSearchMatchesCount ? 'Includes expenses matching your search' : null">
                 + {{ invisibleExpensesCount | shortNumber: '.0-0' }} other
             </a>
         }

--- a/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.scss
+++ b/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.scss
@@ -59,6 +59,15 @@
 .other-label {
     font-size: 12px;
     color: nb-theme(text-info-color);
+    transition: opacity 0.15s ease-in-out;
+
+    &.expense-dimmed {
+        opacity: 0.2;
+    }
+
+    &.has-search-matches {
+        font-weight: nb-theme(text-subtitle-font-weight);
+    }
 }
 
 .unconfirmed-expenses {

--- a/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.ts
+++ b/frontend/src/app/modules/main/calendar/calendar-grid-row-cell-desktop/calendar-grid-row-cell-desktop.component.ts
@@ -12,9 +12,11 @@ import { Expense } from '../../../../api/objects/expense';
 import { ExpenseBalance } from '../../../../api/objects/expense-balance';
 import { ExpenseListDialogComponent } from '../../dialogs/expense-list-dialog/expense-list-dialog.component';
 import { CalendarService } from '../calendar.service';
+import { MainService } from '../../main.service';
 import { CalendarCellInterface } from '../interfaces/calendar-cell.interface';
 import { CalendarGridRowCellDesktopExpenseItemComponent } from './calendar-grid-row-cell-desktop-expense-item/calendar-grid-row-cell-desktop-expense-item.component';
 import { ShortNumberPipe } from '../../../../pipes/shortnumber.pipe';
+import { expenseMatchesSearch, hasExpenseSearchQuery } from '../../../../util/expense-search.util';
 
 export const EXPENSE_LIST_ITEM_HEIGHT = 21;
 
@@ -41,6 +43,7 @@ export class CalendarGridRowCellDesktopComponent
     public hasUnconfirmedExpenses: boolean = false;
 
     private dialogService = inject(NbDialogService);
+    private readonly mainService = inject(MainService);
     private expenseListCapacity: number = 1;
 
     public constructor() {
@@ -55,15 +58,26 @@ export class CalendarGridRowCellDesktopComponent
         return this.expenses.slice(0, this.expenseListCapacity);
     }
 
-    public get invisibleExpensesCount(): number {
-        const visibleCount = this.visibleExpenses.length;
-        const totalCount = this.expenses.length;
+    public get invisibleExpenses(): Expense[] {
+        return this.expenses.slice(this.expenseListCapacity);
+    }
 
-        if (totalCount > visibleCount) {
-            return totalCount - visibleCount;
+    public get invisibleExpensesCount(): number {
+        return this.invisibleExpenses.length;
+    }
+
+    protected get hasSearchQuery(): boolean {
+        return hasExpenseSearchQuery(this.mainService.searchQuery);
+    }
+
+    protected get invisibleSearchMatchesCount(): number {
+        if (!this.hasSearchQuery) {
+            return 0;
         }
 
-        return 0;
+        return this.invisibleExpenses.filter((expense: Expense) =>
+            expenseMatchesSearch(expense, this.mainService.searchQuery)
+        ).length;
     }
 
     public onResized(event: ResizedEvent): void {

--- a/frontend/src/app/util/expense-search.util.spec.ts
+++ b/frontend/src/app/util/expense-search.util.spec.ts
@@ -1,5 +1,5 @@
 import { Expense } from '../api/objects/expense';
-import { expenseMatchesSearch } from './expense-search.util';
+import { expenseMatchesSearch, hasExpenseSearchQuery } from './expense-search.util';
 
 function createExpense(data: Partial<Expense>): Expense {
     return Object.assign(new Expense(), data);
@@ -67,5 +67,19 @@ describe('expenseMatchesSearch', () => {
 
         expect(expenseMatchesSearch(expense, 'anything')).toBeFalse();
         expect(expenseMatchesSearch(expense, '')).toBeTrue();
+    });
+});
+
+describe('hasExpenseSearchQuery', () => {
+    it('is false for empty, blank or nullish queries', (): void => {
+        expect(hasExpenseSearchQuery('')).toBeFalse();
+        expect(hasExpenseSearchQuery('   ')).toBeFalse();
+        expect(hasExpenseSearchQuery(null)).toBeFalse();
+        expect(hasExpenseSearchQuery(undefined)).toBeFalse();
+    });
+
+    it('is true for a query with content', (): void => {
+        expect(hasExpenseSearchQuery('groceries')).toBeTrue();
+        expect(hasExpenseSearchQuery(' 12.5 ')).toBeTrue();
     });
 });

--- a/frontend/src/app/util/expense-search.util.ts
+++ b/frontend/src/app/util/expense-search.util.ts
@@ -3,15 +3,22 @@ import { Expense } from '../api/objects/expense';
 const NUMERIC_QUERY_PATTERN = /^\d+([.,]\d+)?$/;
 
 /**
+ * Tells whether a raw search query contains anything worth filtering by.
+ */
+export function hasExpenseSearchQuery(rawQuery: string): boolean {
+    return !!rawQuery?.trim();
+}
+
+/**
  * Client-side expense search: matches against label, description and absolute amount.
  * An empty (or blank) query matches every expense.
  */
 export function expenseMatchesSearch(expense: Expense, rawQuery: string): boolean {
-    const query = rawQuery?.trim().toLowerCase() ?? '';
-
-    if (!query) {
+    if (!hasExpenseSearchQuery(rawQuery)) {
         return true;
     }
+
+    const query = rawQuery.trim().toLowerCase();
 
     if (expense.label?.toLowerCase().includes(query)) {
         return true;


### PR DESCRIPTION
## Problem

Follow-up to the client-side expense search (7c15406): desktop calendar cells cap visible expense rows via `visibleExpenses` and collapse the rest behind a **+ N other** link. With an active search, matching expenses hidden in that overflow were not surfaced — a day could show every row dimmed while the only match sat behind the link.

## Fix

The overflow link is now search-aware:

- **Bold + tooltip** ("Includes expenses matching your search") when hidden overflow expenses match the query
- **Dimmed** (`opacity: 0.2`, same visual language as dimmed rows) when a search is active but none of the overflow expenses match
- **Unchanged** when there is no search query

Clicking through still opens the day expense-list dialog, where matching rows stand out undimmed.

## Implementation

- New null-safe `hasExpenseSearchQuery()` helper in `expense-search.util.ts` (single source for blank-query semantics); `expenseMatchesSearch()` refactored to use it — behavior unchanged
- `CalendarGridRowCellDesktopComponent`: new `invisibleExpenses` / `invisibleSearchMatchesCount` getters; `invisibleExpensesCount` simplified on top of them
- Link text deliberately unchanged (no match count) to avoid wrapping in narrow day cells

## Verification

- ✅ ESLint clean
- ✅ 88/88 unit tests pass (2 new for `hasExpenseSearchQuery`)
- ✅ Production build passes (`strictTemplates`)