### PR TITLE
fix(frontend): hide header search on mobile

### DIFF
--- a/frontend/src/app/modules/main/header/header.component.html
+++ b/frontend/src/app/modules/main/header/header.component.html
@@ -4,7 +4,7 @@
         <app-header-calendar-info [calendar]="calendar" [visibleDateBalance]="visibleDateBalance" />
     </div>
 
-    <div class="d-flex align-items-center flex-grow-1 mx-3 header-search">
+    <div class="d-none d-md-flex align-items-center flex-grow-1 mx-3 header-search">
         <app-header-search class="w-100" />
     </div>
 


### PR DESCRIPTION
## Summary

Hides the header search bar in mobile view using Bootstrap responsive utilities (`d-none d-md-flex`), so it only renders at the `md` breakpoint (768px) and up.

## Details

- The breakpoint aligns with the Nebular `md` breakpoint already used for `isMobile` detection in `main.component.ts`, keeping responsive behavior consistent.
- Follows the existing pattern of using Bootstrap display utilities for responsive hiding in the header (e.g. `d-none d-sm-block` in `header-nav-buttons.component.ts`).