### PR TITLE
fix(backend): bump phpoffice/phpspreadsheet 5.8.0 → 5.9.0 (security)

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -2146,16 +2146,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.8.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb"
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/01964d92536edf1a3a874b9580a52824bebf6fbb",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,7 @@
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": "^8.1",
+                "php": "^8.2",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
@@ -2191,7 +2191,7 @@
                 "phpstan/phpstan": "^1.1 || ^2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^10.5 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.7",
                 "tecnickcom/tcpdf": "^6.5"
             },
@@ -2249,9 +2249,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.8.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
             },
-            "time": "2026-06-07T03:51:10+00:00"
+            "time": "2026-07-12T19:17:39+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",


### PR DESCRIPTION
## Summary

Updates `phpoffice/phpspreadsheet` from **5.8.0 → 5.9.0** to fix 3 HIGH-severity SSRF vulnerabilities in the `WEBSERVICE()` formula function.

## Vulnerabilities fixed

| CVE | GitHub Alert | Issue |
|---|---|---|
| CVE-2026-59931 | #227 | SSRF bypass via HTTP redirect in `WEBSERVICE()` domain whitelist |
| CVE-2026-59932 | #228 | Same vulnerability class |
| CVE-2026-59933 | #229 | Same vulnerability class |

The domain whitelist introduced in PhpSpreadsheet 5.4.0 only validates the **initial** URL's hostname — `file_get_contents()` follows 301/302 redirects by default without re-validating the redirect target. An attacker able to influence spreadsheet formulas (e.g., via statement imports) could reach internal services through a whitelisted-but-redirecting URL.

## Changes

- `backend/composer.lock` — phpspreadsheet 5.8.0 → 5.9.0 (minimal, 8 insertions / 8 deletions)
- No changes to `composer.json` (constraint `^5.1` already permits the fix)
- No PHP version concern: 5.9.0 requires PHP ^8.2, project runs 8.4

## Verification

- `composer update` reports **"No security vulnerability advisories found"** after the bump
- Statement import unit tests that don't require a database pass
- The 1 failing test (`StatementImportControllerTest`) fails identically on the old version due to a missing PDO MySQL driver in the sandbox — pre-existing environment limitation, unrelated to this change

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._