### PR TITLE
fix(backend): revoke refresh tokens on logout and admin deactivation

### DIFF
--- a/backend/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/backend/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -2,4 +2,4 @@ gesdinet_jwt_refresh_token:
     refresh_token_class: App\Entity\RefreshToken
     token_parameter_name: refreshToken
     single_use: true
-    ttl: 2592000 # 30 days, made explicit; logout and admin deactivation revoke tokens
+    ttl: 2592000

--- a/backend/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/backend/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -2,3 +2,4 @@ gesdinet_jwt_refresh_token:
     refresh_token_class: App\Entity\RefreshToken
     token_parameter_name: refreshToken
     single_use: true
+    ttl: 2592000 # 30 days, made explicit; logout and admin deactivation revoke tokens

--- a/backend/src/Controller/Auth/LogoutController.php
+++ b/backend/src/Controller/Auth/LogoutController.php
@@ -5,17 +5,28 @@ declare(strict_types=1);
 namespace App\Controller\Auth;
 
 use App\Controller\AbstractApiController;
+use App\Entity\User;
+use App\Repository\RefreshTokenRepository;
 use App\Response\EmptyResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 #[Route('api/auth/logout', name: 'logout_')]
 class LogoutController extends AbstractApiController
 {
+    public function __construct(
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+    ) {
+    }
+
     #[Route('', name: 'index', methods: Request::METHOD_DELETE)]
-    public function index(): JsonResponse
+    public function index(#[CurrentUser] User $user): JsonResponse
     {
+        // ponytail: revokes every session of the user; per-device revoke if clients ever send the token
+        $this->refreshTokenRepository->revokeAllForUser($user);
+
         return $this->respond(new EmptyResponse());
     }
 }

--- a/backend/src/Controller/Auth/LogoutController.php
+++ b/backend/src/Controller/Auth/LogoutController.php
@@ -24,7 +24,6 @@ class LogoutController extends AbstractApiController
     #[Route('', name: 'index', methods: Request::METHOD_DELETE)]
     public function index(#[CurrentUser] User $user): JsonResponse
     {
-        // ponytail: revokes every session of the user; per-device revoke if clients ever send the token
         $this->refreshTokenRepository->revokeAllForUser($user);
 
         return $this->respond(new EmptyResponse());

--- a/backend/src/Repository/RefreshTokenRepository.php
+++ b/backend/src/Repository/RefreshTokenRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\RefreshToken;
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends AbstractRepository<RefreshToken>
+ */
+class RefreshTokenRepository extends AbstractRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RefreshToken::class);
+    }
+
+    public function revokeAllForUser(User $user): void
+    {
+        $this->getEntityManager()->createQueryBuilder()
+            ->delete(RefreshToken::class, 't')
+            ->where('t.username = :username')
+            ->setParameter('username', $user->getUserIdentifier())
+            ->getQuery()
+            ->execute()
+        ;
+    }
+}

--- a/backend/src/Service/AdminUserService.php
+++ b/backend/src/Service/AdminUserService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\User;
 use App\Enum\UserRole;
 use App\Exception\DataConflictException;
+use App\Repository\RefreshTokenRepository;
 use App\Repository\UserRepository;
 
 readonly class AdminUserService
@@ -16,6 +17,7 @@ readonly class AdminUserService
     public function __construct(
         private UserRepository $userRepository,
         private PasswordResetService $passwordResetService,
+        private RefreshTokenRepository $refreshTokenRepository,
     ) {
     }
 
@@ -54,6 +56,7 @@ readonly class AdminUserService
         ;
 
         $this->userRepository->save($user);
+        $this->refreshTokenRepository->revokeAllForUser($user);
 
         return $user;
     }

--- a/backend/tests/Application/AuthenticationRequiredTest.php
+++ b/backend/tests/Application/AuthenticationRequiredTest.php
@@ -29,6 +29,7 @@ class AuthenticationRequiredTest extends ApplicationTestCase
     public static function endpointProvider(): array
     {
         return [
+            'Logout' => ['DELETE', '/api/auth/logout'],
             'Profile' => ['GET', '/api/user/profile'],
             'User list' => ['GET', '/api/user'],
             'Calendar list' => ['GET', '/api/calendar'],

--- a/backend/tests/Application/Controller/Auth/LogoutControllerTest.php
+++ b/backend/tests/Application/Controller/Auth/LogoutControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Controller\Auth;
+
+use App\Controller\Auth\LogoutController;
+use App\Entity\RefreshToken;
+use App\Repository\RefreshTokenRepository;
+use App\Tests\ApplicationTestCase;
+use DateTime;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(LogoutController::class)]
+class LogoutControllerTest extends ApplicationTestCase
+{
+    public function testLogoutRevokesRefreshTokens(): void
+    {
+        $client = $this->getAuthenticatedClient();
+        $user = $this->getUser();
+
+        /** @var RefreshTokenRepository $refreshTokenRepository */
+        $refreshTokenRepository = self::getContainer()->get(RefreshTokenRepository::class);
+
+        $refreshTokenRepository->save($this->createRefreshToken('user1-refresh-token', $user->getEmail()));
+        $refreshTokenRepository->save($this->createRefreshToken('user2-refresh-token', 'user2@email.com'));
+
+        $client->jsonRequest('POST', '/api/auth/refresh-token', ['refreshToken' => 'user1-refresh-token']);
+        $this->assertResponseIsSuccessful();
+        $rotatedToken = $this->getJsonResponse($client)['refreshToken'];
+
+        $client->jsonRequest('DELETE', '/api/auth/logout');
+        $this->assertResponseIsSuccessful();
+
+        $client->jsonRequest('POST', '/api/auth/refresh-token', ['refreshToken' => $rotatedToken]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+
+        $this->assertNull($refreshTokenRepository->findOneBy(['username' => $user->getEmail()]));
+        $this->assertNotNull($refreshTokenRepository->findOneBy(['refreshToken' => 'user2-refresh-token']));
+    }
+
+    private function createRefreshToken(string $token, string $username): RefreshToken
+    {
+        return (new RefreshToken())
+            ->setRefreshToken($token)
+            ->setUsername($username)
+            ->setValid(new DateTime('+1 month'))
+        ;
+    }
+}


### PR DESCRIPTION
## Problem

Security audit finding: `DELETE /api/auth/logout` was a no-op — refresh tokens stayed valid for their full gesdinet default lifetime (30 days), so a stolen refresh token survived logout. Same gap in admin deactivation: it cleared the password reset token but left live refresh tokens, and no `user_checker` blocks deactivated accounts.

## Fix

- New `RefreshTokenRepository::revokeAllForUser()` (DQL delete by `username` = user identifier/email).
- `LogoutController` now requires the authenticated user and revokes all their refresh tokens (revokes every session — per-device revoke can come later if clients start sending the token).
- `AdminUserService::deactivate()` revokes the user's refresh tokens too.
- Explicit `ttl: 2592000` in `gesdinet_jwt_refresh_token.yaml`.

No frontend change needed: Nebular already calls `DELETE /auth/logout` and only clears the local token on a successful response, which this keeps (200).

## Tests

- New `LogoutControllerTest`: seeds refresh tokens for two users, rotates one via `POST /api/auth/refresh-token`, logs out, then asserts the rotated token is rejected with 401, the user's rows are gone, and the other user's token is untouched.
- Added logout to `AuthenticationRequiredTest` (no JWT → 401).
- Full suite: 131 tests / 554 assertions OK; PHPStan clean.