### PR TITLE
fix(backend): stop leaking exception internals in prod error responses

### DIFF
--- a/backend/src/Handler/Error/UnhandledExceptionHandler.php
+++ b/backend/src/Handler/Error/UnhandledExceptionHandler.php
@@ -6,12 +6,20 @@ namespace App\Handler\Error;
 
 use App\Exception\UnhandledException;
 use App\Response\Error\ErrorResponseMessage;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 class UnhandledExceptionHandler implements ErrorHandlerInterface
 {
+    private const string GENERIC_MESSAGE = 'Internal server error.';
+
     private Throwable $throwable;
+
+    public function __construct(
+        #[Autowire('%kernel.debug%')] private readonly bool $debug = false
+    ) {
+    }
 
     public function isSupported(Throwable $throwable): bool
     {
@@ -27,7 +35,8 @@ class UnhandledExceptionHandler implements ErrorHandlerInterface
 
     public function getThrowable(): Throwable
     {
-        return $this->throwable;
+        // Hide the real exception class (e.g. Doctrine internals) from API clients in prod.
+        return $this->debug ? $this->throwable : new UnhandledException(self::GENERIC_MESSAGE);
     }
 
     public function getStatusCode(): int
@@ -37,6 +46,10 @@ class UnhandledExceptionHandler implements ErrorHandlerInterface
 
     public function getMessages(): array
     {
+        if (!$this->debug) {
+            return [new ErrorResponseMessage(self::GENERIC_MESSAGE)];
+        }
+
         return [
             new ErrorResponseMessage(
                 $this->throwable->getMessage(),

--- a/backend/src/Resolver/Error/ErrorResponseResolver.php
+++ b/backend/src/Resolver/Error/ErrorResponseResolver.php
@@ -9,6 +9,7 @@ use App\Handler\Error\ErrorHandlerInterface;
 use App\Handler\Error\UnhandledExceptionHandler;
 use App\Response\Error\ErrorResponse;
 use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Throwable;
 
@@ -18,7 +19,8 @@ readonly class ErrorResponseResolver
      * @param iterable<ErrorHandlerInterface> $responseErrorHandlers
      */
     public function __construct(
-        #[AutowireIterator('app.handler.error')] private readonly iterable $responseErrorHandlers
+        #[AutowireIterator('app.handler.error')] private readonly iterable $responseErrorHandlers,
+        #[Autowire('%kernel.debug%')] private readonly bool $debug,
     ) {
     }
 
@@ -31,7 +33,7 @@ readonly class ErrorResponseResolver
         }
 
         return new ErrorResponse(
-            (new UnhandledExceptionHandler())->setThrowable($throwable)
+            (new UnhandledExceptionHandler($this->debug))->setThrowable($throwable)
         );
     }
 }

--- a/backend/tests/Application/Handler/Error/UnhandledExceptionHandlerTest.php
+++ b/backend/tests/Application/Handler/Error/UnhandledExceptionHandlerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Handler\Error;
+
+use App\Exception\UnhandledException;
+use App\Handler\Error\UnhandledExceptionHandler;
+use PDOException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(UnhandledExceptionHandler::class)]
+class UnhandledExceptionHandlerTest extends TestCase
+{
+    public function testDebugModeExposesExceptionDetails(): void
+    {
+        $throwable = new PDOException('SQLSTATE[HY000] connection refused');
+
+        $handler = (new UnhandledExceptionHandler(true))->setThrowable($throwable);
+
+        $this->assertSame($throwable, $handler->getThrowable());
+        $this->assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $handler->getStatusCode());
+
+        $message = $handler->getMessages()[0];
+        $this->assertSame('SQLSTATE[HY000] connection refused', $message->getMessage());
+        $this->assertSame($throwable->getFile(), $message->getFile());
+        $this->assertSame($throwable->getLine(), $message->getLine());
+        $this->assertNotEmpty($message->getTrace());
+    }
+
+    public function testProdModeHidesExceptionDetails(): void
+    {
+        $handler = (new UnhandledExceptionHandler(false))
+            ->setThrowable(new PDOException('SQLSTATE[HY000] connection refused'));
+
+        $this->assertInstanceOf(UnhandledException::class, $handler->getThrowable());
+
+        $message = $handler->getMessages()[0];
+        $this->assertSame('Internal server error.', $message->getMessage());
+        $this->assertNull($message->getFile());
+        $this->assertNull($message->getLine());
+        $this->assertNull($message->getTrace());
+    }
+
+    public function testProdModeIsTheDefault(): void
+    {
+        $handler = (new UnhandledExceptionHandler())
+            ->setThrowable(new PDOException('SQLSTATE[HY000] connection refused'));
+
+        $this->assertSame('Internal server error.', $handler->getMessages()[0]->getMessage());
+    }
+}


### PR DESCRIPTION
## Problem

Security audit finding #1 (CWE-209): the fallback error path returned the raw exception to API clients — `UnhandledExceptionHandler` built an `ErrorResponseMessage` with the real message, absolute file path, line number, and full stack trace, and `ErrorResponse::getThrowable()` exposed the concrete exception class (e.g. `Doctrine\DBAL\Exception\ConnectionException`). Any unhandled 500 (DB error, TypeError, …) disclosed server internals in prod.

## Fix

- `UnhandledExceptionHandler` now takes a `kernel.debug` flag. With debug off (prod): generic `Internal server error.` message, no file/line/trace, and `throwable` reports the generic `App\Exception\UnhandledException` instead of the real class. Debug/test behavior is unchanged, so devs keep full detail.
- `ErrorResponseResolver` passes the flag to the manually constructed fallback handler; the tagged service instance gets it via `#[Autowire('%kernel.debug%')]`.
- Full exception detail is still logged server-side by the kernel's exception listener — nothing lost for debugging.

Known error types (validation, access denied, HTTP exceptions, data conflicts) go through their own handlers with intentional messages — untouched, frontend contract preserved.

## Tests

- New `UnhandledExceptionHandlerTest`: debug mode exposes details; prod mode returns the generic message with null file/line/trace; prod is the constructor default.
- Full suite: 132 tests / 560 assertions OK; PHPStan clean; prod container warmup verified.