### PR TITLE
fix(backend): store only sha256 hash of password reset tokens

### DIFF
--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -229,9 +229,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function hasValidPasswordResetToken(string $token, DateTimeInterface $now): bool
+    public function hasValidPasswordResetToken(string $hashedToken, DateTimeInterface $now): bool
     {
-        return $this->passwordResetToken === $token
+        return $this->passwordResetToken !== null
+            && hash_equals($this->passwordResetToken, $hashedToken)
             && $this->passwordResetTokenExpiresAt !== null
             && $this->passwordResetTokenExpiresAt > $now;
     }

--- a/backend/src/Service/PasswordResetService.php
+++ b/backend/src/Service/PasswordResetService.php
@@ -36,7 +36,7 @@ readonly class PasswordResetService
 
         $token = bin2hex(random_bytes(32));
         $user
-            ->setPasswordResetToken($token)
+            ->setPasswordResetToken(self::hashToken($token))
             ->setPasswordResetTokenExpiresAt(new DateTimeImmutable(sprintf('+%d hour', self::RESET_TOKEN_TTL_HOURS)))
         ;
 
@@ -62,9 +62,10 @@ readonly class PasswordResetService
 
     public function resetPassword(string $hash, string $password): void
     {
-        $user = $this->userRepository->findOneBy(['passwordResetToken' => $hash, 'active' => true]);
+        $hashedToken = self::hashToken($hash);
+        $user = $this->userRepository->findOneBy(['passwordResetToken' => $hashedToken, 'active' => true]);
 
-        if ($user === null || !$user->hasValidPasswordResetToken($hash, new DateTimeImmutable())) {
+        if ($user === null || !$user->hasValidPasswordResetToken($hashedToken, new DateTimeImmutable())) {
             throw new RequestValidationException(new ConstraintViolationList([
                 new ConstraintViolation(
                     self::INVALID_RESET_TOKEN_MESSAGE,
@@ -83,6 +84,12 @@ readonly class PasswordResetService
         ;
 
         $this->userRepository->save($user);
+    }
+
+    // sha256 suffices: 256-bit random tokens have no password-guessing surface.
+    private static function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
     }
 
     private function createResetLink(string $token): string

--- a/backend/tests/Application/Controller/Auth/PasswordControllerTest.php
+++ b/backend/tests/Application/Controller/Auth/PasswordControllerTest.php
@@ -29,7 +29,7 @@ class PasswordControllerTest extends ApplicationTestCase
         $token = 'reset-token';
         $user = $this->getUser();
         $user
-            ->setPasswordResetToken($token)
+            ->setPasswordResetToken(hash('sha256', $token))
             ->setPasswordResetTokenExpiresAt(new DateTimeImmutable('+1 hour'))
         ;
 

--- a/backend/tests/Application/Service/PasswordResetServiceTest.php
+++ b/backend/tests/Application/Service/PasswordResetServiceTest.php
@@ -69,7 +69,11 @@ class PasswordResetServiceTest extends TestCase
                 $this->assertSame(['no-reply@expensave.local'], array_map(static fn ($address): string => $address->getAddress(), $message->getFrom()));
                 $this->assertSame(['user@example.com'], array_map(static fn ($address): string => $address->getAddress(), $message->getTo()));
                 $this->assertStringContainsString('/auth/reset-password?hash=', (string) $message->getTextBody());
-                $this->assertStringContainsString((string) $user->getPasswordResetToken(), (string) $message->getTextBody());
+
+                // The email carries the raw token; only its sha256 hash may be persisted.
+                $this->assertSame(1, preg_match('/hash=([a-f0-9]{64})/', (string) $message->getTextBody(), $matches));
+                $this->assertSame(hash('sha256', $matches[1]), $user->getPasswordResetToken());
+                $this->assertNotSame($matches[1], $user->getPasswordResetToken());
 
                 return true;
             }));
@@ -90,7 +94,7 @@ class PasswordResetServiceTest extends TestCase
         $repo
             ->expects($this->once())
             ->method('findOneBy')
-            ->with(['passwordResetToken' => 'missing-hash', 'active' => true])
+            ->with(['passwordResetToken' => hash('sha256', 'missing-hash'), 'active' => true])
             ->willReturn(null);
 
         $repo
@@ -112,14 +116,14 @@ class PasswordResetServiceTest extends TestCase
             ->setName('User')
             ->setActive(true)
             ->setPassword('current-password-hash')
-            ->setPasswordResetToken('reset-hash')
+            ->setPasswordResetToken(hash('sha256', 'reset-hash'))
             ->setPasswordResetTokenExpiresAt(new DateTimeImmutable('-1 minute'));
 
         $repo = $this->createMock(UserRepository::class);
         $repo
             ->expects($this->once())
             ->method('findOneBy')
-            ->with(['passwordResetToken' => 'reset-hash', 'active' => true])
+            ->with(['passwordResetToken' => hash('sha256', 'reset-hash'), 'active' => true])
             ->willReturn($user);
 
         $repo
@@ -141,14 +145,14 @@ class PasswordResetServiceTest extends TestCase
             ->setName('User')
             ->setActive(true)
             ->setPassword('current-password-hash')
-            ->setPasswordResetToken('reset-hash')
+            ->setPasswordResetToken(hash('sha256', 'reset-hash'))
             ->setPasswordResetTokenExpiresAt(new DateTimeImmutable('+1 hour'));
 
         $repo = $this->createMock(UserRepository::class);
         $repo
             ->expects($this->once())
             ->method('findOneBy')
-            ->with(['passwordResetToken' => 'reset-hash', 'active' => true])
+            ->with(['passwordResetToken' => hash('sha256', 'reset-hash'), 'active' => true])
             ->willReturn($user);
 
         $repo


### PR DESCRIPTION
## Problem

Security audit finding #5: `User.passwordResetToken` held the raw 256-bit reset token. A read-only DB leak (backup, SQLi elsewhere, leaked dump) would expose live, directly usable password-reset tokens — equivalent to account takeover for any user with a pending reset.

## Fix

- `PasswordResetService` stores `hash('sha256', $token)` and hashes the presented token before the `findOneBy` lookup; the raw token exists only in the emailed link.
- `User::hasValidPasswordResetToken()` now takes the hashed token and compares with `hash_equals` (timing-safe), keeping the expiry check.
- sha256 rather than bcrypt on purpose: 256-bit random tokens have no offline-guessing surface, and a slow hash on every reset lookup buys nothing.

## Tests

- `PasswordResetServiceTest`: forgot-flow now extracts the raw token from the email body and asserts only its sha256 hash is persisted (and that the stored value differs from the raw token); reset lookups updated to hashed expectations.
- `PasswordControllerTest` seeds the hashed token; token-cannot-be-used-twice flow still passes end to end.
- Full suite: 129 tests / 550 assertions OK; PHPStan clean.

## Deploy note

Reset links issued before this deploy stop working (stored raw token won't match the hashed lookup). TTL is 1 hour, so impact is negligible.