### PR TITLE
fix(backend): security hygiene — random_bytes secrets, drop abandoned doctrine/annotations

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,7 +10,6 @@
         "ext-iconv": "*",
         "ext-zip": "*",
         "beberlei/doctrineextensions": "^1.5",
-        "doctrine/annotations": "^2.0",
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.2",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92f400828b88c8a5c786245bbf245acb",
+    "content-hash": "8f6e68e0abaf77447d5f59a298a80d26",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -143,83 +143,6 @@
                 }
             ],
             "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.10.28",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6.4 || ^7",
-                "vimeo/psalm": "^4.30 || ^5.14"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
-            },
-            "abandoned": true,
-            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/collections",

--- a/backend/src/Command/RegenerateSecretsCommand.php
+++ b/backend/src/Command/RegenerateSecretsCommand.php
@@ -41,12 +41,6 @@ class RegenerateSecretsCommand extends Command
 
     private function generateSecret(): string
     {
-        $a = '0123456789abcdef';
-        $secret = '';
-        for ($i = 0; $i < 32; $i++) {
-            $secret .= $a[rand(0, 15)];
-        }
-
-        return $secret;
+        return bin2hex(random_bytes(16));
     }
 }


### PR DESCRIPTION
Security audit finding #8 (misc hygiene batch).

## Changes

- **`RegenerateSecretsCommand`**: secret generation used `rand()` (not crypto-secure) in a 7-line loop → `bin2hex(random_bytes(16))`, same 32-char lowercase hex output format, so `.env` regeneration semantics are unchanged. Smoke-tested: replaces all `{REGENERATE_SECRET}` placeholders correctly.
- **Removed `doctrine/annotations`**: abandoned per composer audit; nothing in `src/`/`config/` uses the annotation reader (all PHP attributes). Only the root package required it. `composer audit` is now fully clean — no advisories, no abandoned flags.

## Deliberately not changed

- CORS wildcard listener: already gated to `APP_ENV=dev` only; correct as-is. Ops note: never run prod with `APP_ENV=dev`.
- Open registration default (`REGISTRATION_DISABLED` defaults false): intentional product behavior; set the env var on public deployments.

## Verification

Full suite: 129 tests / 548 assertions OK; PHPStan clean; `composer audit` clean; prod cache warmup ran during `composer remove` without errors.