### PR TITLE
fix(backend): rate limit the password-forgot endpoint

### DIFF
--- a/backend/config/packages/rate_limiter.yaml
+++ b/backend/config/packages/rate_limiter.yaml
@@ -1,0 +1,12 @@
+framework:
+    rate_limiter:
+        password_forgot:
+            policy: 'fixed_window'
+            limit: 3
+            interval: '15 minutes'
+
+when@test:
+    framework:
+        rate_limiter:
+            password_forgot:
+                limit: 1000

--- a/backend/src/Controller/Auth/PasswordController.php
+++ b/backend/src/Controller/Auth/PasswordController.php
@@ -9,16 +9,30 @@ use App\Request\Auth\PasswordForgotRequest;
 use App\Request\Auth\PasswordResetRequest;
 use App\Response\EmptyResponse;
 use App\Service\PasswordResetService;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('api/auth/password', name: 'password_')]
 class PasswordController extends AbstractApiController
 {
     #[Route('/forgot', name: 'forgot', methods: Request::METHOD_POST)]
-    public function forgotPassword(PasswordForgotRequest $request, PasswordResetService $passwordResetService): JsonResponse
-    {
+    public function forgotPassword(
+        PasswordForgotRequest $request,
+        PasswordResetService $passwordResetService,
+        Request $httpRequest,
+        #[Autowire(service: 'limiter.password_forgot')] RateLimiterFactory $passwordForgotLimiter,
+    ): JsonResponse {
+        // Public endpoint that sends email: throttle per client IP and per target address.
+        foreach ([$httpRequest->getClientIp() ?? 'unknown', strtolower($request->getEmail())] as $key) {
+            if (!$passwordForgotLimiter->create($key)->consume()->isAccepted()) {
+                throw new TooManyRequestsHttpException();
+            }
+        }
+
         $passwordResetService->forgotPassword($request->getEmail());
 
         return $this->respond(new EmptyResponse());

--- a/backend/tests/Application/Controller/Auth/PasswordControllerTest.php
+++ b/backend/tests/Application/Controller/Auth/PasswordControllerTest.php
@@ -19,9 +19,23 @@ class PasswordControllerTest extends ApplicationTestCase
 
     public function setUp(): void
     {
+        $_ENV['MAILER_DSN'] = 'null://null';
+        putenv('MAILER_DSN=null://null');
+
         parent::setUp();
 
         $this->client = $this->getAuthenticatedClient();
+    }
+
+    public function testForgotPasswordIsAccepted(): void
+    {
+        $user = $this->getUser();
+
+        $this->client->jsonRequest('POST', '/api/auth/password/forgot', ['email' => $user->getEmail()]);
+        $this->assertResponseIsSuccessful();
+
+        static::getContainer()->get('doctrine')->getManager()->refresh($user);
+        $this->assertNotNull($user->getPasswordResetToken());
     }
 
     public function testResetPasswordTokenCannotBeUsedTwice(): void

--- a/backend/tests/Application/Controller/Auth/PasswordForgotThrottleTest.php
+++ b/backend/tests/Application/Controller/Auth/PasswordForgotThrottleTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Controller\Auth;
+
+use App\Controller\Auth\PasswordController;
+use App\Request\Auth\PasswordForgotRequest;
+use App\Service\PasswordResetService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+#[CoversClass(PasswordController::class)]
+class PasswordForgotThrottleTest extends TestCase
+{
+    public function testForgotPasswordIsThrottledByIp(): void
+    {
+        $limiterFactory = $this->createLimiterFactory();
+        $limiterFactory->create('127.0.0.1')->consume(); // drain the IP budget
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $this->callForgot($limiterFactory);
+    }
+
+    public function testForgotPasswordIsThrottledByEmail(): void
+    {
+        $limiterFactory = $this->createLimiterFactory();
+        $limiterFactory->create('user@example.com')->consume(); // drain the email budget
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $this->callForgot($limiterFactory);
+    }
+
+    private function callForgot(RateLimiterFactory $limiterFactory): void
+    {
+        $passwordResetService = $this->createMock(PasswordResetService::class);
+        $passwordResetService->expects($this->never())->method('forgotPassword');
+
+        $request = (new PasswordForgotRequest([], new RequestStack()))->setEmail('user@example.com');
+
+        (new PasswordController())->forgotPassword(
+            $request,
+            $passwordResetService,
+            Request::create('/api/auth/password/forgot', Request::METHOD_POST),
+            $limiterFactory,
+        );
+    }
+
+    private function createLimiterFactory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'password_forgot', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '15 minutes'],
+            new InMemoryStorage(),
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Security audit finding #6: `POST /api/auth/password/forgot` was public and unthrottled — anyone could trigger unlimited password-reset emails to a known address (mail bomb / harassment). Login had `login_throttling`; this endpoint had nothing.

## Fix

- New `password_forgot` rate limiter (`config/packages/rate_limiter.yaml`): fixed window, **3 per 15 minutes**.
- `PasswordController::forgotPassword` consumes the limiter twice — keyed by **client IP** (generic flooding) and by **target email** (targeted mail-bombing from rotating IPs) — and throws 429 before any mail is sent. 429 flows through the existing `HttpExceptionHandler`, so the JSON error shape is unchanged.
- The admin-triggered reset (`Admin\UserManagementController`) deliberately bypasses the limiter.
- `when@test` raises the limit to keep the test suite hermetic (limiter storage is `cache.app`, which persists across runs).

Implementation note: this Symfony version registers no `RateLimiterFactory $passwordForgotLimiter` named alias, so injection is by service id (`#[Autowire(service: 'limiter.password_forgot')]`).

## Tests

- New `PasswordForgotThrottleTest` (unit, real `RateLimiterFactory` + `InMemoryStorage`): IP-budget exhaustion and email-budget exhaustion each yield 429 and the reset service is never called.
- New functional `testForgotPasswordIsAccepted`: legit request still succeeds and the (hashed) reset token is persisted.
- Full suite: 137 tests / 574 assertions OK; PHPStan clean.